### PR TITLE
Basic framework for handling ratings for multiple inputs

### DIFF
--- a/examples/rec_ratings.ipynb
+++ b/examples/rec_ratings.ipynb
@@ -21,8 +21,8 @@
    "id": "65004bb8",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T02:10:11.751200Z",
-     "start_time": "2021-04-12T02:09:01.504763Z"
+     "end_time": "2021-04-12T04:28:04.412936Z",
+     "start_time": "2021-04-12T04:27:24.065154Z"
     }
    },
    "outputs": [
@@ -39,8 +39,6 @@
     }
    ],
    "source": [
-    "# gensim had to be installed separately (setup.py wasn't working)\n",
-    "\n",
     "from wikirec import data_utils, model, utils\n",
     "import os\n",
     "import json\n",
@@ -60,12 +58,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "9e7a9710",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T02:30:37.450845Z",
-     "start_time": "2021-04-12T02:30:37.433523Z"
+     "end_time": "2021-04-12T04:28:04.427950Z",
+     "start_time": "2021-04-12T04:28:04.414937Z"
     }
    },
    "outputs": [],
@@ -75,12 +73,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "d4505134",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T02:30:42.778870Z",
-     "start_time": "2021-04-12T02:30:38.987683Z"
+     "end_time": "2021-04-12T04:28:10.967311Z",
+     "start_time": "2021-04-12T04:28:07.569134Z"
     }
    },
    "outputs": [
@@ -102,12 +100,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "9aa016d4",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T02:30:44.568708Z",
-     "start_time": "2021-04-12T02:30:44.547680Z"
+     "end_time": "2021-04-12T04:28:10.983327Z",
+     "start_time": "2021-04-12T04:28:10.969313Z"
     }
    },
    "outputs": [],
@@ -118,12 +116,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "bf57a0d5",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T02:30:56.234632Z",
-     "start_time": "2021-04-12T02:30:55.059499Z"
+     "end_time": "2021-04-12T04:28:12.494860Z",
+     "start_time": "2021-04-12T04:28:10.985329Z"
     }
    },
    "outputs": [
@@ -171,17 +169,17 @@
    "id": "8b9656b5",
    "metadata": {},
    "source": [
-    "# Preparing TFIDF model for recommendations"
+    "# Preparing a TFIDF model for recommendations"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "4947cfbf",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T02:31:26.542646Z",
-     "start_time": "2021-04-12T02:31:26.523629Z"
+     "end_time": "2021-04-12T04:28:16.229146Z",
+     "start_time": "2021-04-12T04:28:16.208127Z"
     }
    },
    "outputs": [],
@@ -223,112 +221,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
-   "id": "e8c9d929",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-04-12T03:51:19.647204Z",
-     "start_time": "2021-04-12T03:51:19.637194Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "def recommend(\n",
-    "    inputs=None, ratings = None, titles=None, sim_matrix=None, metric=\"cosine\", n=10,\n",
-    "):\n",
-    "    \"\"\"\n",
-    "    Recommends similar items given an input or list of inputs of interest.\n",
-    "\n",
-    "    Parameters\n",
-    "    ----------\n",
-    "        inputs : str or list (default=None)\n",
-    "            The name of an item or items of interest\n",
-    "\n",
-    "        titles : lists (default=None)\n",
-    "            The titles of the articles\n",
-    "\n",
-    "        sim_matrix : gensim.interfaces.TransformedCorpus or np.ndarray (default=None)\n",
-    "            The similarity sim_matrix for the corpus from the given model\n",
-    "\n",
-    "        n : int (default=10)\n",
-    "            The number of items to recommend\n",
-    "\n",
-    "        metric : str (default=cosine)\n",
-    "            The metric to be used when comparing vectorized corpus entries\n",
-    "\n",
-    "            Options include: cosine and euclidean\n",
-    "\n",
-    "    Returns\n",
-    "    -------\n",
-    "        recommendations : list of lists\n",
-    "            Those items that are most similar to the inputs and their similarity scores\n",
-    "    \"\"\"\n",
-    "    if isinstance(inputs, str):\n",
-    "        inputs = [inputs]\n",
-    "        \n",
-    "    if ratings:\n",
-    "        # compute weights based on number of inputs\n",
-    "        weights = np.divide(ratings, sum(ratings))\n",
-    "\n",
-    "    first_input = True\n",
-    "    for r, inpt in enumerate(inputs):\n",
-    "        checked = 0\n",
-    "        num_missing = 0\n",
-    "        for i, t in enumerate(titles):\n",
-    "            if t == inpt:\n",
-    "                if first_input:\n",
-    "                    sims = sim_matrix[i]\n",
-    "\n",
-    "                    first_input = False\n",
-    "                    \n",
-    "                    if ratings:\n",
-    "                        sims = sims * weights[0]\n",
-    "\n",
-    "                else:\n",
-    "                    if ratings:\n",
-    "                        sims = [np.mean([s, weights[r] * sim_matrix[i][j]]) for j, s in enumerate(sims)]\n",
-    "                        \n",
-    "                        # scale the ratings to get comparable similarity scores \n",
-    "                        if r == (len(ratings) - 1):\n",
-    "                            sims = [s*len(ratings) for s in sims]\n",
-    "                    else:\n",
-    "                        sims = [np.mean([s, sim_matrix[i][j]]) for j, s in enumerate(sims)]\n",
-    "                \n",
-    "\n",
-    "            else:\n",
-    "                checked += 1\n",
-    "                if checked == len(titles):\n",
-    "                    num_missing += 1\n",
-    "                    print(f\"{inpt} not available\")\n",
-    "                    utils._check_str_args(arguments=inpt, valid_args=titles)\n",
-    "\n",
-    "                    if num_missing == len(inputs):\n",
-    "                        ValueError(\n",
-    "                            \"None of the provided inputs were found in the index. Please check them and reference Wikipedia for valid inputs via article names.\"\n",
-    "                        )\n",
-    "\n",
-    "    titles_and_scores = [[t, sims[i]] for i, t in enumerate(titles)]\n",
-    "\n",
-    "    if metric == \"cosine\":\n",
-    "        # Cosine similarities have been used (higher is better)\n",
-    "        recommendations = sorted(titles_and_scores, key=lambda x: x[1], reverse=True)\n",
-    "    elif metric == \"euclidean\":\n",
-    "        # Euclidean distances have been used (lower is better)\n",
-    "        recommendations = sorted(titles_and_scores, key=lambda x: x[1], reverse=False)\n",
-    "\n",
-    "    recommendations = [r for r in recommendations if r[0] not in inputs][:n]\n",
-    "\n",
-    "    return recommendations"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 7,
    "id": "223db7bc",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T03:15:55.083188Z",
-     "start_time": "2021-04-12T03:14:39.378446Z"
+     "end_time": "2021-04-12T04:28:35.621416Z",
+     "start_time": "2021-04-12T04:28:21.648429Z"
     }
    },
    "outputs": [
@@ -354,28 +252,30 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9040dca3",
+   "id": "430937dc",
    "metadata": {},
    "source": [
-    "# Utilizing the ratings for making recommendations"
+    "# Utilizing the ratings for making recommendations\n",
+    "Ratings for each input are restricted to be less than 10, and greater than or equal to 0"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2477836f",
+   "id": "14978e10",
    "metadata": {},
    "source": [
-    "## No ratings (simply averages them)"
+    "## No ratings \n",
+    "Ratings are simply averaged"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 8,
    "id": "1d3c7d13",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T03:44:37.790765Z",
-     "start_time": "2021-04-12T03:44:37.361376Z"
+     "end_time": "2021-04-12T04:28:40.665525Z",
+     "start_time": "2021-04-12T04:28:40.217118Z"
     }
    },
    "outputs": [
@@ -394,13 +294,13 @@
        " ['Harry Potter and the Prisoner of Azkaban', 0.2645807400342994]]"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "recommend(\n",
+    "model.recommend(\n",
     "    inputs=[\"Harry Potter and the Philosopher's Stone\", \"The Hobbit\"],\n",
     "    ratings = None,\n",
     "    titles=selected_titles,\n",
@@ -411,50 +311,8 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 93,
-   "id": "d84bf89c",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2021-04-12T03:51:27.866251Z",
-     "start_time": "2021-04-12T03:51:27.417175Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[['The History of The Hobbit', 0.39543687196383887],\n",
-       " ['The Annotated Hobbit', 0.3363038160377437],\n",
-       " ['Harry Potter and the Deathly Hallows', 0.31365133665137784],\n",
-       " ['Harry Potter and the Chamber of Secrets', 0.30697017204471655],\n",
-       " ['Harry Potter and the Order of the Phoenix', 0.3050990193809162],\n",
-       " ['Harry Potter and the Goblet of Fire', 0.3008483408564587],\n",
-       " ['Harry Potter and the Half-Blood Prince', 0.29072541606015917],\n",
-       " ['The Magical Worlds of Harry Potter', 0.27557913845105425],\n",
-       " ['The Lord of the Rings', 0.2705902834440923],\n",
-       " ['Harry Potter and the Prisoner of Azkaban', 0.2645807400342994]]"
-      ]
-     },
-     "execution_count": 93,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "recommend(\n",
-    "    inputs=[\"Harry Potter and the Philosopher's Stone\", \"The Hobbit\"],\n",
-    "    ratings = [1,1],\n",
-    "    titles=selected_titles,\n",
-    "    sim_matrix=tfidf_sim_matrix,\n",
-    "    n=10,\n",
-    "    metric=\"cosine\",\n",
-    ")"
-   ]
-  },
-  {
    "cell_type": "markdown",
-   "id": "31a2a46b",
+   "id": "890e469a",
    "metadata": {},
    "source": [
     "## Rating them with a slight preference\n",
@@ -463,37 +321,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
-   "id": "2a584095",
+   "execution_count": 9,
+   "id": "a54b0653",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T03:33:54.701395Z",
-     "start_time": "2021-04-12T03:33:54.253676Z"
+     "end_time": "2021-04-12T04:28:48.982642Z",
+     "start_time": "2021-04-12T04:28:48.400113Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[['Harry Potter and the Deathly Hallows', 0.18033784648608733],\n",
-       " ['Harry Potter and the Chamber of Secrets', 0.17594624462307532],\n",
-       " ['Harry Potter and the Order of the Phoenix', 0.1756540960132673],\n",
-       " ['Harry Potter and the Goblet of Fire', 0.1726741972850122],\n",
-       " ['Harry Potter and the Half-Blood Prince', 0.16668867872859788],\n",
-       " ['The History of The Hobbit', 0.16547755013570214],\n",
-       " ['The Magical Worlds of Harry Potter', 0.1563955007984641],\n",
-       " ['Harry Potter and the Prisoner of Azkaban', 0.15039618037214678],\n",
-       " ['The Annotated Hobbit', 0.14085849302448103],\n",
-       " ['Fantastic Beasts and Where to Find Them', 0.14042896585808473]]"
+       "[['Harry Potter and the Deathly Hallows', 0.30657433902634845],\n",
+       " ['Harry Potter and the Chamber of Secrets', 0.299108615859228],\n",
+       " ['Harry Potter and the Order of the Phoenix', 0.2986119632225544],\n",
+       " ['Harry Potter and the Goblet of Fire', 0.2935461353845208],\n",
+       " ['Harry Potter and the Half-Blood Prince', 0.28337075383861643],\n",
+       " ['The History of The Hobbit', 0.28131183523069364],\n",
+       " ['The Magical Worlds of Harry Potter', 0.2658723513573889],\n",
+       " ['Harry Potter and the Prisoner of Azkaban', 0.25567350663264954],\n",
+       " ['The Annotated Hobbit', 0.23945943814161777],\n",
+       " ['Fantastic Beasts and Where to Find Them', 0.23872924195874404]]"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "recommend(\n",
+    "model.recommend(\n",
     "    inputs=[\"Harry Potter and the Philosopher's Stone\", \"The Hobbit\"],\n",
     "    ratings=[10, 7],\n",
     "    titles=selected_titles,\n",
@@ -505,48 +363,48 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ababe5db",
+   "id": "c9688f44",
    "metadata": {},
    "source": [
     "## Completely different ratings\n",
-    "The recommendations get dominated by Harry Potter-related books. "
+    "The recommendations become dominated by Harry Potter-related books. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 17,
    "id": "5825f720",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T03:51:40.301500Z",
-     "start_time": "2021-04-12T03:51:39.705115Z"
+     "end_time": "2021-04-12T04:32:07.224929Z",
+     "start_time": "2021-04-12T04:32:06.784321Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[['Harry Potter and the Deathly Hallows', 0.5316733523205266],\n",
-       " ['Harry Potter and the Order of the Phoenix', 0.5193415471015106],\n",
-       " ['Harry Potter and the Chamber of Secrets', 0.5152463699786378],\n",
-       " ['Harry Potter and the Goblet of Fire', 0.5071667717102636],\n",
-       " ['Harry Potter and the Half-Blood Prince', 0.48847532617369244],\n",
-       " ['The Magical Worlds of Harry Potter', 0.44810686758192414],\n",
-       " ['Harry Potter and the Prisoner of Azkaban', 0.4324709815079089],\n",
-       " ['Harry Potter and the Methods of Rationality', 0.40968395333697355],\n",
-       " ['Fantastic Beasts and Where to Find Them', 0.40658222086493995],\n",
-       " ['Harry, A History', 0.39851750751938997]]"
+       "[['Harry Potter and the Deathly Hallows', 0.29477934298463276],\n",
+       " ['Harry Potter and the Order of the Phoenix', 0.2878002029586181],\n",
+       " ['Harry Potter and the Chamber of Secrets', 0.28600602221674704],\n",
+       " ['Harry Potter and the Goblet of Fire', 0.28137579293129095],\n",
+       " ['Harry Potter and the Half-Blood Prince', 0.27111298346937845],\n",
+       " ['The Magical Worlds of Harry Potter', 0.2496943728679467],\n",
+       " ['Harry Potter and the Prisoner of Azkaban', 0.24082811762989983],\n",
+       " ['Harry Potter and the Methods of Rationality', 0.22732611579756462],\n",
+       " ['Fantastic Beasts and Where to Find Them', 0.22613839155622148],\n",
+       " ['Harry, A History', 0.2210389981400308]]"
       ]
      },
-     "execution_count": 94,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "recommend(\n",
+    "model.recommend(\n",
     "    inputs=[\"Harry Potter and the Philosopher's Stone\", \"The Hobbit\"],\n",
-    "    ratings=[10, 1],\n",
+    "    ratings=[10, 2],\n",
     "    titles=selected_titles,\n",
     "    sim_matrix=tfidf_sim_matrix,\n",
     "    n=10,\n",
@@ -556,7 +414,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f06e8c79",
+   "id": "f40df22a",
    "metadata": {},
    "source": [
     "## Let's try out more books and ratings"
@@ -564,49 +422,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
-   "id": "24e87082",
+   "execution_count": 136,
+   "id": "0f4d1d6c",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T03:51:46.526863Z",
-     "start_time": "2021-04-12T03:51:45.689093Z"
+     "end_time": "2021-04-12T04:23:55.810813Z",
+     "start_time": "2021-04-12T04:23:54.976055Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[['Mockingjay', 0.31480874258417063],\n",
-       " ['Catching Fire', 0.2994814770252149],\n",
-       " ['Harry Potter and the Deathly Hallows', 0.2570596127501137],\n",
-       " ['Harry Potter and the Order of the Phoenix', 0.2555220410683682],\n",
-       " ['Harry Potter and the Goblet of Fire', 0.24831425745082442],\n",
-       " ['Harry Potter and the Chamber of Secrets', 0.24626256775293565],\n",
-       " ['Harry Potter and the Half-Blood Prince', 0.23938628740774218],\n",
-       " ['Harry Potter and the Prisoner of Azkaban', 0.22674636201363085],\n",
-       " ['The Ballad of Songbirds and Snakes', 0.2211152005365305],\n",
-       " ['The Magical Worlds of Harry Potter', 0.21119311863026252],\n",
-       " ['Fantastic Beasts and Where to Find Them', 0.19749803207545133],\n",
-       " ['The Bone Season', 0.19459012004314707],\n",
-       " ['Harry Potter and the Cursed Child', 0.19273396967259301],\n",
-       " ['Harry, A History', 0.1896708634434452],\n",
-       " ['Harry Potter and the Methods of Rationality', 0.1895936627076112],\n",
-       " ['Divergent', 0.18482139471796297],\n",
-       " ['The Casual Vacancy', 0.1820582051350734],\n",
-       " ['The Ickabog', 0.16790599281721247],\n",
-       " ['Children of Blood and Bone', 0.1598282367723854],\n",
-       " ['Peter and the Starcatchers', 0.15961990762368836]]"
+       "[['Mockingjay', 0.21346548642816926],\n",
+       " ['Catching Fire', 0.20226095072454017],\n",
+       " ['Harry Potter and the Deathly Hallows', 0.1737320743750856],\n",
+       " ['Harry Potter and the Order of the Phoenix', 0.1725103794316994],\n",
+       " ['Harry Potter and the Goblet of Fire', 0.1679769067911956],\n",
+       " ['Harry Potter and the Chamber of Secrets', 0.16679556389711997],\n",
+       " ['Harry Potter and the Half-Blood Prince', 0.1620424123456757],\n",
+       " ['Harry Potter and the Prisoner of Azkaban', 0.15413331914297052],\n",
+       " ['The Ballad of Songbirds and Snakes', 0.14946601578333799],\n",
+       " ['The Magical Worlds of Harry Potter', 0.14403100811806346],\n",
+       " ['Fantastic Beasts and Where to Find Them', 0.13418352479747206],\n",
+       " ['The Bone Season', 0.13221999759079664],\n",
+       " ['Harry Potter and the Cursed Child', 0.1306396136199141],\n",
+       " ['Harry Potter and the Methods of Rationality', 0.12839571660063662],\n",
+       " ['Harry, A History', 0.12830161129999643],\n",
+       " ['Divergent', 0.12655723857232776],\n",
+       " ['The Casual Vacancy', 0.12434690730231132],\n",
+       " ['The Ickabog', 0.11490321520162539],\n",
+       " ['The History of The Hobbit', 0.11240034831162313],\n",
+       " ['Children of Blood and Bone', 0.11067462542037988]]"
       ]
      },
-     "execution_count": 95,
+     "execution_count": 136,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "recommend(\n",
+    "model.recommend(\n",
     "    inputs=[\"Harry Potter and the Philosopher's Stone\", \"The Hobbit\", \"The Hunger Games\"],\n",
-    "    ratings=[10, 3, 7],\n",
+    "    ratings=[10, 5, 7],\n",
     "    titles=selected_titles,\n",
     "    sim_matrix=tfidf_sim_matrix,\n",
     "    n=20,\n",

--- a/examples/rec_ratings.ipynb
+++ b/examples/rec_ratings.ipynb
@@ -1,0 +1,657 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d6b07698",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-07T20:30:31.031707Z",
+     "start_time": "2021-04-07T20:30:31.016696Z"
+    }
+   },
+   "source": [
+    "**rec_ratings**:\n",
+    "\n",
+    "Tests the functionality of using multiple inputs with multiple assigned ratings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "65004bb8",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-12T02:10:11.751200Z",
+     "start_time": "2021-04-12T02:09:01.504763Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:tensorflow:Enabling eager execution\n",
+      "INFO:tensorflow:Enabling v2 tensorshape\n",
+      "INFO:tensorflow:Enabling resource variables\n",
+      "INFO:tensorflow:Enabling tensor equality\n",
+      "INFO:tensorflow:Enabling control flow v2\n"
+     ]
+    }
+   ],
+   "source": [
+    "# gensim had to be installed separately (setup.py wasn't working)\n",
+    "\n",
+    "from wikirec import data_utils, model, utils\n",
+    "import os\n",
+    "import json\n",
+    "import pickle\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47ce8291",
+   "metadata": {},
+   "source": [
+    "# Import existing data "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "9e7a9710",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-12T02:30:37.450845Z",
+     "start_time": "2021-04-12T02:30:37.433523Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "topic = \"books\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d4505134",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-12T02:30:42.778870Z",
+     "start_time": "2021-04-12T02:30:38.987683Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found a total of 41234 books.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Make sure to extract the .zip file containing enwiki_books.ndjson\n",
+    "with open(\"./enwiki_books.ndjson/enwiki_books.ndjson\", \"r\") as fin:\n",
+    "    books = [json.loads(l) for l in fin]\n",
+    "\n",
+    "print(f\"Found a total of {len(books)} books.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9aa016d4",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-12T02:30:44.568708Z",
+     "start_time": "2021-04-12T02:30:44.547680Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "titles = [m[0] for m in books] # Titles of each book\n",
+    "texts = [m[1] for m in books] # The text from the English Wiki Articles of each page "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "bf57a0d5",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-12T02:30:56.234632Z",
+     "start_time": "2021-04-12T02:30:55.059499Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading book corpus and selected indexes\n"
+     ]
+    }
+   ],
+   "source": [
+    "if os.path.isfile(\"./book_corpus_idxs.pkl\"):\n",
+    "    print(f\"Loading book corpus and selected indexes\")\n",
+    "    with open(f\"./book_corpus_idxs.pkl\", \"rb\") as f:\n",
+    "        text_corpus, selected_idxs = pickle.load(f)\n",
+    "        selected_titles = [titles[i] for i in selected_idxs]\n",
+    "\n",
+    "else:\n",
+    "    print(f\"Creating book corpus and selected indexes\")\n",
+    "    text_corpus, selected_idxs = data_utils.clean(\n",
+    "        texts=texts,\n",
+    "        language=\"en\",\n",
+    "        min_token_freq=5,  # 0 for Bert\n",
+    "        min_token_len=3,  # 0 for Bert\n",
+    "        min_tokens=50,\n",
+    "        max_token_index=-1,\n",
+    "        min_ngram_count=3,\n",
+    "        remove_stopwords=True,  # False for Bert\n",
+    "        ignore_words=None,\n",
+    "        remove_names=True,\n",
+    "        sample_size=1,\n",
+    "        verbose=True,\n",
+    "    )\n",
+    "\n",
+    "    selected_titles = [titles[i] for i in selected_idxs]\n",
+    "\n",
+    "    with open(\"./book_corpus_idxs.pkl\", \"wb\") as f:\n",
+    "        print(\"Pickling book corpus and selected indexes\")\n",
+    "        pickle.dump([text_corpus, selected_idxs], f, protocol=4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b9656b5",
+   "metadata": {},
+   "source": [
+    "# Preparing TFIDF model for recommendations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "4947cfbf",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-12T02:31:26.542646Z",
+     "start_time": "2021-04-12T02:31:26.523629Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def load_or_create_sim_matrix(\n",
+    "    method,\n",
+    "    corpus,\n",
+    "    metric,\n",
+    "    topic,\n",
+    "    path=\"./\",\n",
+    "    bert_st_model=\"xlm-r-bert-base-nli-stsb-mean-tokens\",\n",
+    "    **kwargs,\n",
+    "):\n",
+    "    \"\"\"\n",
+    "    Loads or creats a similarity matrix to deliver recommendations\n",
+    "    \n",
+    "    NOTE: the .pkl files made are 5-10GB or more in size\n",
+    "    \"\"\"\n",
+    "    if os.path.isfile(f\"{path}{topic}_{metric}_{method}_sim_matrix.pkl\"):\n",
+    "        print(f\"Loading {method} {topic} {metric} similarity matrix\")\n",
+    "        with open(f\"{path}{topic}_{metric}_{method}_sim_matrix.pkl\", \"rb\") as f:\n",
+    "            sim_matrix = pickle.load(f)\n",
+    "\n",
+    "    else:\n",
+    "        print(f\"Creating {method} {topic} {metric} similarity matrix\")\n",
+    "        embeddings = model.gen_embeddings(\n",
+    "            method=method, corpus=corpus, bert_st_model=bert_st_model, **kwargs,\n",
+    "        )\n",
+    "        sim_matrix = model.gen_sim_matrix(\n",
+    "            method=method, metric=metric, embeddings=embeddings,\n",
+    "        )\n",
+    "\n",
+    "        with open(f\"{path}{topic}_{metric}_{method}_sim_matrix.pkl\", \"wb\") as f:\n",
+    "            print(f\"Pickling {method} {topic} {metric} similarity matrix\")\n",
+    "            pickle.dump(sim_matrix, f, protocol=4)\n",
+    "\n",
+    "    return sim_matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "id": "e8c9d929",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-12T03:51:19.647204Z",
+     "start_time": "2021-04-12T03:51:19.637194Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def recommend(\n",
+    "    inputs=None, ratings = None, titles=None, sim_matrix=None, metric=\"cosine\", n=10,\n",
+    "):\n",
+    "    \"\"\"\n",
+    "    Recommends similar items given an input or list of inputs of interest.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "        inputs : str or list (default=None)\n",
+    "            The name of an item or items of interest\n",
+    "\n",
+    "        titles : lists (default=None)\n",
+    "            The titles of the articles\n",
+    "\n",
+    "        sim_matrix : gensim.interfaces.TransformedCorpus or np.ndarray (default=None)\n",
+    "            The similarity sim_matrix for the corpus from the given model\n",
+    "\n",
+    "        n : int (default=10)\n",
+    "            The number of items to recommend\n",
+    "\n",
+    "        metric : str (default=cosine)\n",
+    "            The metric to be used when comparing vectorized corpus entries\n",
+    "\n",
+    "            Options include: cosine and euclidean\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "        recommendations : list of lists\n",
+    "            Those items that are most similar to the inputs and their similarity scores\n",
+    "    \"\"\"\n",
+    "    if isinstance(inputs, str):\n",
+    "        inputs = [inputs]\n",
+    "        \n",
+    "    if ratings:\n",
+    "        # compute weights based on number of inputs\n",
+    "        weights = np.divide(ratings, sum(ratings))\n",
+    "\n",
+    "    first_input = True\n",
+    "    for r, inpt in enumerate(inputs):\n",
+    "        checked = 0\n",
+    "        num_missing = 0\n",
+    "        for i, t in enumerate(titles):\n",
+    "            if t == inpt:\n",
+    "                if first_input:\n",
+    "                    sims = sim_matrix[i]\n",
+    "\n",
+    "                    first_input = False\n",
+    "                    \n",
+    "                    if ratings:\n",
+    "                        sims = sims * weights[0]\n",
+    "\n",
+    "                else:\n",
+    "                    if ratings:\n",
+    "                        sims = [np.mean([s, weights[r] * sim_matrix[i][j]]) for j, s in enumerate(sims)]\n",
+    "                        \n",
+    "                        # scale the ratings to get comparable similarity scores \n",
+    "                        if r == (len(ratings) - 1):\n",
+    "                            sims = [s*len(ratings) for s in sims]\n",
+    "                    else:\n",
+    "                        sims = [np.mean([s, sim_matrix[i][j]]) for j, s in enumerate(sims)]\n",
+    "                \n",
+    "\n",
+    "            else:\n",
+    "                checked += 1\n",
+    "                if checked == len(titles):\n",
+    "                    num_missing += 1\n",
+    "                    print(f\"{inpt} not available\")\n",
+    "                    utils._check_str_args(arguments=inpt, valid_args=titles)\n",
+    "\n",
+    "                    if num_missing == len(inputs):\n",
+    "                        ValueError(\n",
+    "                            \"None of the provided inputs were found in the index. Please check them and reference Wikipedia for valid inputs via article names.\"\n",
+    "                        )\n",
+    "\n",
+    "    titles_and_scores = [[t, sims[i]] for i, t in enumerate(titles)]\n",
+    "\n",
+    "    if metric == \"cosine\":\n",
+    "        # Cosine similarities have been used (higher is better)\n",
+    "        recommendations = sorted(titles_and_scores, key=lambda x: x[1], reverse=True)\n",
+    "    elif metric == \"euclidean\":\n",
+    "        # Euclidean distances have been used (lower is better)\n",
+    "        recommendations = sorted(titles_and_scores, key=lambda x: x[1], reverse=False)\n",
+    "\n",
+    "    recommendations = [r for r in recommendations if r[0] not in inputs][:n]\n",
+    "\n",
+    "    return recommendations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "223db7bc",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-12T03:15:55.083188Z",
+     "start_time": "2021-04-12T03:14:39.378446Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading tfidf books cosine similarity matrix\n"
+     ]
+    }
+   ],
+   "source": [
+    "tfidf_sim_matrix = load_or_create_sim_matrix(\n",
+    "    method=\"tfidf\",\n",
+    "    corpus=text_corpus,\n",
+    "    metric=\"cosine\",  # euclidean\n",
+    "    topic=topic,\n",
+    "    path=\"./\",\n",
+    "    max_features=None,\n",
+    "    norm='l2',\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9040dca3",
+   "metadata": {},
+   "source": [
+    "# Utilizing the ratings for making recommendations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2477836f",
+   "metadata": {},
+   "source": [
+    "## No ratings (simply averages them)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "id": "1d3c7d13",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-12T03:44:37.790765Z",
+     "start_time": "2021-04-12T03:44:37.361376Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[['The History of The Hobbit', 0.39543687196383887],\n",
+       " ['The Annotated Hobbit', 0.3363038160377437],\n",
+       " ['Harry Potter and the Deathly Hallows', 0.31365133665137784],\n",
+       " ['Harry Potter and the Chamber of Secrets', 0.30697017204471655],\n",
+       " ['Harry Potter and the Order of the Phoenix', 0.3050990193809162],\n",
+       " ['Harry Potter and the Goblet of Fire', 0.3008483408564587],\n",
+       " ['Harry Potter and the Half-Blood Prince', 0.29072541606015917],\n",
+       " ['The Magical Worlds of Harry Potter', 0.27557913845105425],\n",
+       " ['The Lord of the Rings', 0.2705902834440923],\n",
+       " ['Harry Potter and the Prisoner of Azkaban', 0.2645807400342994]]"
+      ]
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "recommend(\n",
+    "    inputs=[\"Harry Potter and the Philosopher's Stone\", \"The Hobbit\"],\n",
+    "    ratings = None,\n",
+    "    titles=selected_titles,\n",
+    "    sim_matrix=tfidf_sim_matrix,\n",
+    "    n=10,\n",
+    "    metric=\"cosine\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "id": "d84bf89c",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-12T03:51:27.866251Z",
+     "start_time": "2021-04-12T03:51:27.417175Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[['The History of The Hobbit', 0.39543687196383887],\n",
+       " ['The Annotated Hobbit', 0.3363038160377437],\n",
+       " ['Harry Potter and the Deathly Hallows', 0.31365133665137784],\n",
+       " ['Harry Potter and the Chamber of Secrets', 0.30697017204471655],\n",
+       " ['Harry Potter and the Order of the Phoenix', 0.3050990193809162],\n",
+       " ['Harry Potter and the Goblet of Fire', 0.3008483408564587],\n",
+       " ['Harry Potter and the Half-Blood Prince', 0.29072541606015917],\n",
+       " ['The Magical Worlds of Harry Potter', 0.27557913845105425],\n",
+       " ['The Lord of the Rings', 0.2705902834440923],\n",
+       " ['Harry Potter and the Prisoner of Azkaban', 0.2645807400342994]]"
+      ]
+     },
+     "execution_count": 93,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "recommend(\n",
+    "    inputs=[\"Harry Potter and the Philosopher's Stone\", \"The Hobbit\"],\n",
+    "    ratings = [1,1],\n",
+    "    titles=selected_titles,\n",
+    "    sim_matrix=tfidf_sim_matrix,\n",
+    "    n=10,\n",
+    "    metric=\"cosine\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31a2a46b",
+   "metadata": {},
+   "source": [
+    "## Rating them with a slight preference\n",
+    "Notice the slight change in order, with preference for Harry Potter books being shifted higher."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "2a584095",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-12T03:33:54.701395Z",
+     "start_time": "2021-04-12T03:33:54.253676Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[['Harry Potter and the Deathly Hallows', 0.18033784648608733],\n",
+       " ['Harry Potter and the Chamber of Secrets', 0.17594624462307532],\n",
+       " ['Harry Potter and the Order of the Phoenix', 0.1756540960132673],\n",
+       " ['Harry Potter and the Goblet of Fire', 0.1726741972850122],\n",
+       " ['Harry Potter and the Half-Blood Prince', 0.16668867872859788],\n",
+       " ['The History of The Hobbit', 0.16547755013570214],\n",
+       " ['The Magical Worlds of Harry Potter', 0.1563955007984641],\n",
+       " ['Harry Potter and the Prisoner of Azkaban', 0.15039618037214678],\n",
+       " ['The Annotated Hobbit', 0.14085849302448103],\n",
+       " ['Fantastic Beasts and Where to Find Them', 0.14042896585808473]]"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "recommend(\n",
+    "    inputs=[\"Harry Potter and the Philosopher's Stone\", \"The Hobbit\"],\n",
+    "    ratings=[10, 7],\n",
+    "    titles=selected_titles,\n",
+    "    sim_matrix=tfidf_sim_matrix,\n",
+    "    n=10,\n",
+    "    metric=\"cosine\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ababe5db",
+   "metadata": {},
+   "source": [
+    "## Completely different ratings\n",
+    "The recommendations get dominated by Harry Potter-related books. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "id": "5825f720",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-12T03:51:40.301500Z",
+     "start_time": "2021-04-12T03:51:39.705115Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[['Harry Potter and the Deathly Hallows', 0.5316733523205266],\n",
+       " ['Harry Potter and the Order of the Phoenix', 0.5193415471015106],\n",
+       " ['Harry Potter and the Chamber of Secrets', 0.5152463699786378],\n",
+       " ['Harry Potter and the Goblet of Fire', 0.5071667717102636],\n",
+       " ['Harry Potter and the Half-Blood Prince', 0.48847532617369244],\n",
+       " ['The Magical Worlds of Harry Potter', 0.44810686758192414],\n",
+       " ['Harry Potter and the Prisoner of Azkaban', 0.4324709815079089],\n",
+       " ['Harry Potter and the Methods of Rationality', 0.40968395333697355],\n",
+       " ['Fantastic Beasts and Where to Find Them', 0.40658222086493995],\n",
+       " ['Harry, A History', 0.39851750751938997]]"
+      ]
+     },
+     "execution_count": 94,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "recommend(\n",
+    "    inputs=[\"Harry Potter and the Philosopher's Stone\", \"The Hobbit\"],\n",
+    "    ratings=[10, 1],\n",
+    "    titles=selected_titles,\n",
+    "    sim_matrix=tfidf_sim_matrix,\n",
+    "    n=10,\n",
+    "    metric=\"cosine\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f06e8c79",
+   "metadata": {},
+   "source": [
+    "## Let's try out more books and ratings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 95,
+   "id": "24e87082",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2021-04-12T03:51:46.526863Z",
+     "start_time": "2021-04-12T03:51:45.689093Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[['Mockingjay', 0.31480874258417063],\n",
+       " ['Catching Fire', 0.2994814770252149],\n",
+       " ['Harry Potter and the Deathly Hallows', 0.2570596127501137],\n",
+       " ['Harry Potter and the Order of the Phoenix', 0.2555220410683682],\n",
+       " ['Harry Potter and the Goblet of Fire', 0.24831425745082442],\n",
+       " ['Harry Potter and the Chamber of Secrets', 0.24626256775293565],\n",
+       " ['Harry Potter and the Half-Blood Prince', 0.23938628740774218],\n",
+       " ['Harry Potter and the Prisoner of Azkaban', 0.22674636201363085],\n",
+       " ['The Ballad of Songbirds and Snakes', 0.2211152005365305],\n",
+       " ['The Magical Worlds of Harry Potter', 0.21119311863026252],\n",
+       " ['Fantastic Beasts and Where to Find Them', 0.19749803207545133],\n",
+       " ['The Bone Season', 0.19459012004314707],\n",
+       " ['Harry Potter and the Cursed Child', 0.19273396967259301],\n",
+       " ['Harry, A History', 0.1896708634434452],\n",
+       " ['Harry Potter and the Methods of Rationality', 0.1895936627076112],\n",
+       " ['Divergent', 0.18482139471796297],\n",
+       " ['The Casual Vacancy', 0.1820582051350734],\n",
+       " ['The Ickabog', 0.16790599281721247],\n",
+       " ['Children of Blood and Bone', 0.1598282367723854],\n",
+       " ['Peter and the Starcatchers', 0.15961990762368836]]"
+      ]
+     },
+     "execution_count": 95,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "recommend(\n",
+    "    inputs=[\"Harry Potter and the Philosopher's Stone\", \"The Hobbit\", \"The Hunger Games\"],\n",
+    "    ratings=[10, 3, 7],\n",
+    "    titles=selected_titles,\n",
+    "    sim_matrix=tfidf_sim_matrix,\n",
+    "    n=20,\n",
+    "    metric=\"cosine\",\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.2"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {
+    "height": "calc(100% - 180px)",
+    "left": "10px",
+    "top": "150px",
+    "width": "384px"
+   },
+   "toc_section_display": true,
+   "toc_window_display": true
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/wikirec/model.py
+++ b/src/wikirec/model.py
@@ -234,7 +234,7 @@ def gen_sim_matrix(
 
 
 def recommend(
-    inputs=None, titles=None, sim_matrix=None, metric="cosine", n=10,
+    inputs=None, ratings = None, titles=None, sim_matrix=None, metric="cosine", n=10,
 ):
     """
     Recommends similar items given an input or list of inputs of interest.
@@ -265,9 +265,13 @@ def recommend(
     """
     if isinstance(inputs, str):
         inputs = [inputs]
+        
+    if ratings:
+        # compute weights based on number of inputs
+        weights = np.divide(ratings, sum(ratings))
 
     first_input = True
-    for inpt in inputs:
+    for r, inpt in enumerate(inputs):
         checked = 0
         num_missing = 0
         for i, t in enumerate(titles):
@@ -276,10 +280,16 @@ def recommend(
                     sims = sim_matrix[i]
 
                     first_input = False
+                    
+                    if ratings:
+                        sims = sims * weights[0]
 
                 else:
-                    sims = [np.mean([s, sim_matrix[i][j]]) for j, s in enumerate(sims)]
-
+                    if ratings: # Currently only supports ratings if multiple inputs are given     
+                        sims = [np.mean([s, weights[r] * sim_matrix[i][j]]) for j, s in enumerate(sims)]
+                    else:
+                        sims = [np.mean([s, sim_matrix[i][j]]) for j, s in enumerate(sims)]
+                    
             else:
                 checked += 1
                 if checked == len(titles):

--- a/src/wikirec/model.py
+++ b/src/wikirec/model.py
@@ -243,6 +243,9 @@ def recommend(
     ----------
         inputs : str or list (default=None)
             The name of an item or items of interest
+            
+        ratings : list (default=None)
+            A list of ratings that correspond to each input. len(ratings) must equal len(inputs)
 
         titles : lists (default=None)
             The titles of the articles
@@ -267,8 +270,11 @@ def recommend(
         inputs = [inputs]
         
     if ratings:
-        # compute weights based on number of inputs
-        weights = np.divide(ratings, sum(ratings))
+        if any([True for k in ratings if (k > 10) | (k < 0)]):
+            raise ValueError(
+                "Ratings must be between 0 and 10."
+            )
+        weights = np.divide(ratings, 10)
 
     first_input = True
     for r, inpt in enumerate(inputs):
@@ -285,11 +291,12 @@ def recommend(
                         sims = sims * weights[0]
 
                 else:
-                    if ratings: # Currently only supports ratings if multiple inputs are given     
-                        sims = [np.mean([s, weights[r] * sim_matrix[i][j]]) for j, s in enumerate(sims)]
+                    if ratings:
+                        sims = [np.mean([s, weights[r] * sim_matrix[i][j]]) for j, s in enumerate(sims)]    
                     else:
                         sims = [np.mean([s, sim_matrix[i][j]]) for j, s in enumerate(sims)]
-                    
+                
+
             else:
                 checked += 1
                 if checked == len(titles):


### PR DESCRIPTION
Pertains to issue #32: 

I put together simple changes to the  `model.recommend()` function, adding a keyword argument that would handle ratings (as long as it matches the amount of inputs). In terms of scaling the similarity scores, I've restricted the ratings to be between 0 and 10, and weighed the inputs accordingly, such that similarity scores are bounded to be between 0 and 1 (as they were before). I would still want to devise different ways to combine recommendations, as weighted average may not be the only way to approach this.

For a simple demonstration, I've put together a notebook under examples (loosely based off existing examples), and showed the differences that ratings can have on the resulting recommendations. 
