### PR TITLE
Slight fix to how multiple inputs are averaged

### DIFF
--- a/examples/rec_ratings.ipynb
+++ b/examples/rec_ratings.ipynb
@@ -21,8 +21,8 @@
    "id": "65004bb8",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T04:28:04.412936Z",
-     "start_time": "2021-04-12T04:27:24.065154Z"
+     "end_time": "2021-04-14T18:10:38.870643Z",
+     "start_time": "2021-04-14T18:10:32.229165Z"
     }
    },
    "outputs": [
@@ -62,8 +62,8 @@
    "id": "9e7a9710",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T04:28:04.427950Z",
-     "start_time": "2021-04-12T04:28:04.414937Z"
+     "end_time": "2021-04-14T18:10:38.886657Z",
+     "start_time": "2021-04-14T18:10:38.872644Z"
     }
    },
    "outputs": [],
@@ -77,8 +77,8 @@
    "id": "d4505134",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T04:28:10.967311Z",
-     "start_time": "2021-04-12T04:28:07.569134Z"
+     "end_time": "2021-04-14T18:10:40.790386Z",
+     "start_time": "2021-04-14T18:10:38.889661Z"
     }
    },
    "outputs": [
@@ -104,8 +104,8 @@
    "id": "9aa016d4",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T04:28:10.983327Z",
-     "start_time": "2021-04-12T04:28:10.969313Z"
+     "end_time": "2021-04-14T18:10:40.806402Z",
+     "start_time": "2021-04-14T18:10:40.792390Z"
     }
    },
    "outputs": [],
@@ -120,8 +120,8 @@
    "id": "bf57a0d5",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T04:28:12.494860Z",
-     "start_time": "2021-04-12T04:28:10.985329Z"
+     "end_time": "2021-04-14T18:10:41.254808Z",
+     "start_time": "2021-04-14T18:10:40.807402Z"
     }
    },
    "outputs": [
@@ -178,8 +178,8 @@
    "id": "4947cfbf",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T04:28:16.229146Z",
-     "start_time": "2021-04-12T04:28:16.208127Z"
+     "end_time": "2021-04-14T18:10:41.301851Z",
+     "start_time": "2021-04-14T18:10:41.255809Z"
     }
    },
    "outputs": [],
@@ -225,8 +225,8 @@
    "id": "223db7bc",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T04:28:35.621416Z",
-     "start_time": "2021-04-12T04:28:21.648429Z"
+     "end_time": "2021-04-14T18:10:45.004730Z",
+     "start_time": "2021-04-14T18:10:41.303853Z"
     }
    },
    "outputs": [
@@ -270,12 +270,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "id": "1d3c7d13",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T04:28:40.665525Z",
-     "start_time": "2021-04-12T04:28:40.217118Z"
+     "end_time": "2021-04-14T18:11:11.941915Z",
+     "start_time": "2021-04-14T18:11:11.467483Z"
     }
    },
    "outputs": [
@@ -294,7 +294,7 @@
        " ['Harry Potter and the Prisoner of Azkaban', 0.2645807400342994]]"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -321,12 +321,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "a54b0653",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T04:28:48.982642Z",
-     "start_time": "2021-04-12T04:28:48.400113Z"
+     "end_time": "2021-04-14T18:11:05.426909Z",
+     "start_time": "2021-04-14T18:11:04.939485Z"
     }
    },
    "outputs": [
@@ -345,7 +345,7 @@
        " ['Fantastic Beasts and Where to Find Them', 0.23872924195874404]]"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -372,12 +372,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 12,
    "id": "5825f720",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T04:32:07.224929Z",
-     "start_time": "2021-04-12T04:32:06.784321Z"
+     "end_time": "2021-04-14T18:11:17.105916Z",
+     "start_time": "2021-04-14T18:11:16.635533Z"
     }
    },
    "outputs": [
@@ -393,10 +393,15 @@
        " ['Harry Potter and the Prisoner of Azkaban', 0.24082811762989983],\n",
        " ['Harry Potter and the Methods of Rationality', 0.22732611579756462],\n",
        " ['Fantastic Beasts and Where to Find Them', 0.22613839155622148],\n",
-       " ['Harry, A History', 0.2210389981400308]]"
+       " ['Harry, A History', 0.2210389981400308],\n",
+       " ['Harry Potter and the Cursed Child', 0.22078239641328692],\n",
+       " ['The Casual Vacancy', 0.1933741447502036],\n",
+       " ['The Ickabog', 0.18729998944935433],\n",
+       " ['Pollomuhku ja Posityyhtynen', 0.1701209697837757],\n",
+       " ['Quidditch Through the Ages', 0.14644881625297318]]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -407,7 +412,7 @@
     "    ratings=[10, 2],\n",
     "    titles=selected_titles,\n",
     "    sim_matrix=tfidf_sim_matrix,\n",
-    "    n=10,\n",
+    "    n=15,\n",
     "    metric=\"cosine\",\n",
     ")"
    ]
@@ -422,41 +427,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 136,
+   "execution_count": 13,
    "id": "0f4d1d6c",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2021-04-12T04:23:55.810813Z",
-     "start_time": "2021-04-12T04:23:54.976055Z"
+     "end_time": "2021-04-14T18:11:22.735298Z",
+     "start_time": "2021-04-14T18:11:21.836491Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[['Mockingjay', 0.21346548642816926],\n",
-       " ['Catching Fire', 0.20226095072454017],\n",
-       " ['Harry Potter and the Deathly Hallows', 0.1737320743750856],\n",
-       " ['Harry Potter and the Order of the Phoenix', 0.1725103794316994],\n",
-       " ['Harry Potter and the Goblet of Fire', 0.1679769067911956],\n",
-       " ['Harry Potter and the Chamber of Secrets', 0.16679556389711997],\n",
-       " ['Harry Potter and the Half-Blood Prince', 0.1620424123456757],\n",
-       " ['Harry Potter and the Prisoner of Azkaban', 0.15413331914297052],\n",
-       " ['The Ballad of Songbirds and Snakes', 0.14946601578333799],\n",
-       " ['The Magical Worlds of Harry Potter', 0.14403100811806346],\n",
-       " ['Fantastic Beasts and Where to Find Them', 0.13418352479747206],\n",
-       " ['The Bone Season', 0.13221999759079664],\n",
-       " ['Harry Potter and the Cursed Child', 0.1306396136199141],\n",
-       " ['Harry Potter and the Methods of Rationality', 0.12839571660063662],\n",
-       " ['Harry, A History', 0.12830161129999643],\n",
-       " ['Divergent', 0.12655723857232776],\n",
-       " ['The Casual Vacancy', 0.12434690730231132],\n",
-       " ['The Ickabog', 0.11490321520162539],\n",
-       " ['The History of The Hobbit', 0.11240034831162313],\n",
-       " ['Children of Blood and Bone', 0.11067462542037988]]"
+       "[['Mockingjay', 0.2833900475601968],\n",
+       " ['Catching Fire', 0.2667058570158859],\n",
+       " ['Harry Potter and the Deathly Hallows', 0.2441572424724626],\n",
+       " ['Harry Potter and the Order of the Phoenix', 0.24185900215519326],\n",
+       " ['Harry Potter and the Goblet of Fire', 0.2361172970905478],\n",
+       " ['Harry Potter and the Chamber of Secrets', 0.2351746504405977],\n",
+       " ['Harry Potter and the Half-Blood Prince', 0.2279300124518356],\n",
+       " ['Harry Potter and the Prisoner of Azkaban', 0.21689561851501843],\n",
+       " ['The History of The Hobbit', 0.21330459347629357],\n",
+       " ['The Magical Worlds of Harry Potter', 0.20485904169643493],\n",
+       " ['The Ballad of Songbirds and Snakes', 0.1969163655963662],\n",
+       " ['Fantastic Beasts and Where to Find Them', 0.18965280996309142],\n",
+       " ['Harry Potter and the Cursed Child', 0.18417542815018734],\n",
+       " ['Harry Potter and the Methods of Rationality', 0.18141303011897664],\n",
+       " ['Harry, A History', 0.1806894597581523],\n",
+       " ['The Bone Season', 0.1805092769052663],\n",
+       " ['The Annotated Hobbit', 0.18036065589770353],\n",
+       " ['The Lord of the Rings', 0.17740191382248888],\n",
+       " ['The Casual Vacancy', 0.17589666271490761],\n",
+       " ['Divergent', 0.17065269422678103]]"
       ]
      },
-     "execution_count": 136,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -464,7 +469,7 @@
    "source": [
     "model.recommend(\n",
     "    inputs=[\"Harry Potter and the Philosopher's Stone\", \"The Hobbit\", \"The Hunger Games\"],\n",
-    "    ratings=[10, 5, 7],\n",
+    "    ratings=[7, 5, 9],\n",
     "    titles=selected_titles,\n",
     "    sim_matrix=tfidf_sim_matrix,\n",
     "    n=20,\n",

--- a/src/wikirec/model.py
+++ b/src/wikirec/model.py
@@ -293,12 +293,12 @@ def recommend(
                 else:
                     if ratings:
                         sims = [
-                            np.mean([s, weights[r] * sim_matrix[i][j]])
+                            np.mean([r * s, weights[r] * sim_matrix[i][j]])
                             for j, s in enumerate(sims)
                         ]
                     else:
                         sims = [
-                            np.mean([s, sim_matrix[i][j]]) for j, s in enumerate(sims)
+                            np.mean([r * s, sim_matrix[i][j]]) for j, s in enumerate(sims)
                         ]
 
             else:


### PR DESCRIPTION
Problem from #32 : the way `sims` was being averaged for multiple inputs involved computing the mean between the current `sims` matrix, and a new input. This causes issues because it is taking the mean between a value that was already a mean, and a new value, which creates a preference towards the latest input. 

Solution: Fixed how the average of multiple inputs is calculated. Now, when computing the mean, the current `sims` is multiplied by `r`, which is the number of inputs included in sims so far. That way, previously included inputs are given proper weight compared to the latest input. 

