### PR TITLE
Add wikilinks NN method for generating embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 [![codestyle](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![colab](https://img.shields.io/badge/%20-Open%20in%20Colab-097ABB.svg?logo=google-colab&color=097ABB&labelColor=525252)](https://colab.research.google.com/github/andrewtavis/wikirec)
 
-### NLP recommendation engine based on Wikipedia data
+### Recommendation engine framework based on Wikipedia data
 
-**wikirec** is a framework that allows users to parse Wikipedia in any language for entries of a given type and then seamlessly generate recommendations based on unsupervised natural language processing. Along with NLP based similarity recommendations, user ratings can also be leveraged to weigh inputs and indicate preferences. The goal is for wikirec to both refine and deploy models that provide accurate content recommendations based solely on open-source data.
+**wikirec** is a framework that allows users to parse Wikipedia in any language for entries of a given type and then seamlessly generate recommendations for the given content. Recommendations are based on unsupervised natural language processing over article texts, with ratings being leveraged to weigh inputs and indicate preferences. The goal is for wikirec to both refine and deploy models that provide accurate content recommendations with only open-source data.
 
 See the [documentation](https://wikirec.readthedocs.io/en/latest/) for a full outline of the package including models and data preparation.
 
@@ -212,23 +212,22 @@ tfidf_embeddings = model.gen_embeddings(
 <p>
 </details>
 
-<details><summary><strong>Wikilink NN (WIP)</strong></summary>
+<details><summary><strong>Wikilink NN</strong></summary>
 <p>
 
-WIP - see [the issue](https://github.com/andrewtavis/wikirec/issues/36)
-
-Based on this [Towards Data Science article](https://towardsdatascience.com/building-a-recommendation-system-using-neural-network-embeddings-1ef92e5c80c9), the wikilink neural network method makes the assumption that Wikipedia articles that are linked to the same articles will themselves be similar.
-
-`Pseudocode` follows:
+Based on this [Towards Data Science article](https://towardsdatascience.com/building-a-recommendation-system-using-neural-network-embeddings-1ef92e5c80c9), the wikilinks neural network method makes the assumption that content will be similar if they are linked to the same Wikipedia articles. A corpus of internal wikilinks per article is passed, and embeddings based on these internal references are then derived.
 
 ```python
 from wikirec import model
 
-wikilink_nn_embeddings = model.gen_embeddings(
-        method="wikilink_nn",
-        corpus=wikilinks,
+wikilink_embeddings = model.gen_embeddings(
+        method="WikilinkNN",
+        path_to_json="./enwiki_books.ndjson",  # json used instead of a corpus
+        embedding_size=50,
 )
 ```
+
+The [examples](https://github.com/andrewtavis/wikirec/tree/main/examples) directory has a copy of `books_embedding_model.h5` for testing purposes.
 
 <p>
 </details>
@@ -258,11 +257,15 @@ recs = model.recommend(
 
 # Comparative Results [`↩`](#contents) <a id="comparative-results"></a>
 
-TFIDF generally outperformed all other methods in terms of providing what the user would expect, with the results being all the more striking considering its runtime is by far the shortest. The other strong performing model is BERT, as it does the best job of providing novel but sensible recommendations. LDA with the second shortest runtime provides novel recommendations along with what is expected, but recommends things that seem out of place more often than BERT. Doc2vec performs very poorly in that most results are nonsense, and it further takes the longest to train.
+- TFIDF generally outperformed all other NLP methods in terms of providing what the user would expect, with the results being all the more striking considering its runtime is by far the shortest.
+- The other strong performing NLP model is BERT, as it does the best job of providing novel but sensible recommendations.
+- The wikilink neural network also provides very sensible results, giving wikirec effective modeling options using different methods.
+- LDA with the second shortest runtime provides novel recommendations along with what is expected, but recommends things that seem out of place more often than BERT.
+- Doc2vec performs very poorly in that most results are nonsense, and it further takes the longest to train.
 
 See [examples/rec_books](https://github.com/andrewtavis/wikirec/blob/main/examples/rec_books.ipynb) and [examples/rec_movies](https://github.com/andrewtavis/wikirec/blob/main/examples/rec_movies.ipynb) for detailed demonstrations with model comparisons, as well as [examples/rec_ratings](https://github.com/andrewtavis/wikirec/blob/main/examples/rec_ratings.ipynb) for how to leverage user ratings. These notebooks can also be opened in [Google Colab](https://colab.research.google.com/github/andrewtavis/wikirec) for direct experimentation.
 
-Samples of TFIDF and BERT book recommendations using cosine similarity follow:
+Samples of TFIDF, BERT and WikilinkNN book recommendations using cosine similarity follow:
 
 <details><summary><strong>Baseline NLP Models</strong></summary>
 <p>
@@ -487,6 +490,18 @@ model.recommend(
  ['Harry Potter and the Goblet of Fire', 0.5346379229854734],
  ['The Children of Húrin', 0.5340832788476909],
  ['A Wizard of Earthsea', 0.5297755576425843]]
+```
+
+<p>
+</details>
+
+<details><summary><strong>Wikilink NN</strong></summary>
+<p>
+
+```_output
+-- Wikilink Neural Network Ratings --
+
+[]
 ```
 
 <p>

--- a/README.md
+++ b/README.md
@@ -212,10 +212,10 @@ tfidf_embeddings = model.gen_embeddings(
 <p>
 </details>
 
-<details><summary><strong>Wikilink NN</strong></summary>
+<details><summary><strong>WikilinkNN</strong></summary>
 <p>
 
-Based on this [Towards Data Science article](https://towardsdatascience.com/building-a-recommendation-system-using-neural-network-embeddings-1ef92e5c80c9), the wikilinks neural network method makes the assumption that content will be similar if they are linked to the same Wikipedia articles. A corpus of internal wikilinks per article is passed, and embeddings based on these internal references are then derived.
+Based on this [Towards Data Science article](https://towardsdatascience.com/building-a-recommendation-system-using-neural-network-embeddings-1ef92e5c80c9), the wikilink neural network method makes the assumption that content will be similar if they are linked to the same Wikipedia articles. A corpus of internal wikilinks per article is passed, and embeddings based on these internal references are then derived.
 
 ```python
 from wikirec import model
@@ -223,7 +223,10 @@ from wikirec import model
 wikilink_embeddings = model.gen_embeddings(
         method="WikilinkNN",
         path_to_json="./enwiki_books.ndjson",  # json used instead of a corpus
-        embedding_size=50,
+        path_to_embedding_model="books_embedding_model.h5",
+        embedding_size=75,
+        epochs=20,
+        verbose=True,
 )
 ```
 
@@ -259,22 +262,18 @@ recs = model.recommend(
 
 - TFIDF generally outperformed all other NLP methods in terms of providing what the user would expect, with the results being all the more striking considering its runtime is by far the shortest.
 - The other strong performing NLP model is BERT, as it does the best job of providing novel but sensible recommendations.
-- The wikilink neural network also provides very sensible results, giving wikirec effective modeling options using different methods.
+- WikilinkNN also provides very sensible results, giving wikirec effective modeling options using different kinds of inputs.
 - LDA with the second shortest runtime provides novel recommendations along with what is expected, but recommends things that seem out of place more often than BERT.
 - Doc2vec performs very poorly in that most results are nonsense, and it further takes the longest to train.
 
 See [examples/rec_books](https://github.com/andrewtavis/wikirec/blob/main/examples/rec_books.ipynb) and [examples/rec_movies](https://github.com/andrewtavis/wikirec/blob/main/examples/rec_movies.ipynb) for detailed demonstrations with model comparisons, as well as [examples/rec_ratings](https://github.com/andrewtavis/wikirec/blob/main/examples/rec_ratings.ipynb) for how to leverage user ratings. These notebooks can also be opened in [Google Colab](https://colab.research.google.com/github/andrewtavis/wikirec) for direct experimentation.
 
-Samples of TFIDF, BERT and WikilinkNN book recommendations using cosine similarity follow:
+Sample recommendations for single and multiple inputs are found in the following dropdowns:
 
-<details><summary><strong>Baseline NLP Models</strong></summary>
+<details><summary><strong>TFIDF</strong></summary>
 <p>
 
-Recommendations for single and multiple inputs follow:
-
 ```_output
--- TFIDF --
-
 Harry Potter and the Philosopher's Stone recommendations:
 [['Harry Potter and the Chamber of Secrets', 0.5974588223913879],
  ['Harry Potter and the Deathly Hallows', 0.5803045645372675],
@@ -310,10 +309,16 @@ Harry Potter and the Philosopher's Stone and The Hobbit recommendations:
  ['Mr. Bliss', 0.3219122094772891],
  ['Harry Potter and the Order of the Phoenix', 0.3160426316664049],
  ['The Magical Worlds of Harry Potter', 0.30770960167033506]]
+```
 
- -- BERT --
+<p>
+</details>
 
- Harry Potter and the Philosopher's Stone recommendations:
+<details><summary><strong>BERT</strong></summary>
+<p>
+
+```_output
+Harry Potter and the Philosopher's Stone recommendations:
 [['Harry Potter and the Prisoner of Azkaban', 0.8625375],
  ['Harry Potter and the Chamber of Secrets', 0.8557441],
  ['Harry Potter and the Half-Blood Prince', 0.8430752],
@@ -325,7 +330,7 @@ Harry Potter and the Philosopher's Stone and The Hobbit recommendations:
  ['The Weirdstone of Brisingamen', 0.8035261],
  ['Harry Potter and the Cursed Child', 0.79987496]]
 
- The Hobbit recommendations:
+The Hobbit recommendations:
 [['The Lord of the Rings', 0.8724792],
  ['Beast', 0.8283818],
  ['The Children of Húrin', 0.8261733],
@@ -337,7 +342,7 @@ Harry Potter and the Philosopher's Stone and The Hobbit recommendations:
  ['The Amazing Maurice and His Educated Rodents', 0.8089799],
  ['Dark Lord of Derkholm', 0.8068354]]
 
- Harry Potter and the Philosopher's Stone and The Hobbit recommendations:
+Harry Potter and the Philosopher's Stone and The Hobbit recommendations:
 [['The Weirdstone of Brisingamen', 0.79162943],
  ['Harry Potter and the Prisoner of Azkaban', 0.7681779],
  ['A Wizard of Earthsea', 0.7566709],
@@ -353,7 +358,52 @@ Harry Potter and the Philosopher's Stone and The Hobbit recommendations:
 <p>
 </details>
 
-<details><summary><strong>Weighted NLP Approach</strong></summary>
+<details><summary><strong>WikilinkNN</strong></summary>
+<p>
+
+```_output
+Harry Potter and the Philosopher's Stone recommendations:
+[['Harry Potter and the Chamber of Secrets', 0.9697026],
+ ['Harry Potter and the Goblet of Fire', 0.969065],
+ ['Harry Potter and the Deathly Hallows', 0.9685888],
+ ['Harry Potter and the Half-Blood Prince', 0.9635748],
+ ['Harry Potter and the Prisoner of Azkaban', 0.9569129],
+ ['Harry Potter and the Order of the Phoenix', 0.94091964],
+ ['Harry Potter and the Cursed Child', 0.9358928],
+ ['My Immortal (fan fiction)', 0.91195196],
+ ['Eragon', 0.89236057],
+ ['Quidditch Through the Ages', 0.8891448]]
+
+The Hobbit recommendations:
+[['The Lord of the Rings', 0.94245297],
+ ['The Silmarillion', 0.9160445],
+ ['Beren and Lúthien', 0.90604335],
+ ['The Fall of Gondolin', 0.9044683],
+ ['The Children of Húrin', 0.895282],
+ ['The Book of Lost Tales', 0.89020956],
+ ['The Road to Middle-Earth', 0.88268256],
+ ["The Magician's Nephew", 0.8816683],
+ ['The History of The Hobbit', 0.87789804],
+ ['Farmer Giles of Ham', 0.87786204]]
+
+Harry Potter and the Philosopher's Stone and The Hobbit recommendations:
+[['The Lord of the Rings', 0.8367433249950409],
+ ['Harry Potter and the Deathly Hallows', 0.8294640183448792],
+ ['The Children of Húrin', 0.8240831792354584],
+ ['Harry Potter and the Prisoner of Azkaban', 0.8158660233020782],
+ ['Harry Potter and the Goblet of Fire', 0.8150344789028168],
+ ['Eragon', 0.8118217587471008],
+ ['Harry Potter and the Chamber of Secrets', 0.8101150393486023],
+ ['Fantastic Beasts and Where to Find Them', 0.8092647194862366],
+ ['Watership Down', 0.8012698292732239],
+ ['Harry Potter and the Half-Blood Prince', 0.7979166805744171]]
+
+```
+
+<p>
+</details>
+
+<details><summary><strong>Weighted Model Approach</strong></summary>
 <p>
 
 Better results can be achieved by combining TFIDF and BERT:
@@ -367,7 +417,7 @@ bert_tfidf_sim_matrix = tfidf_weight * tfidf_sim_matrix + bert_weight * bert_sim
 ```_output
 -- Weighted BERT and TFIDF --
 
- Harry Potter and the Philosopher's Stone recommendations:
+Harry Potter and the Philosopher's Stone recommendations:
 [['Harry Potter and the Chamber of Secrets', 0.7653442323224594],
  ['Harry Potter and the Half-Blood Prince', 0.7465576592959889],
  ['Harry Potter and the Goblet of Fire', 0.7381149146065132],
@@ -379,7 +429,7 @@ bert_tfidf_sim_matrix = tfidf_weight * tfidf_sim_matrix + bert_weight * bert_sim
  ['The Ickabog', 0.6218310147923186],
  ['Fantastic Beasts and Where to Find Them', 0.6161251907593163]]
 
- The Hobbit recommendations:
+The Hobbit recommendations:
 [['The History of The Hobbit', 0.78046806361336],
  ['The Lord of the Rings', 0.764041360399863],
  ['The Annotated Hobbit', 0.7444487700381719],
@@ -391,7 +441,7 @@ bert_tfidf_sim_matrix = tfidf_weight * tfidf_sim_matrix + bert_weight * bert_sim
  ['J. R. R. Tolkien: A Biography', 0.6391232063030203],
  ['Tolkien: Maker of Middle-earth', 0.6309609890944725]]
 
- Harry Potter and the Philosopher's Stone and The Hobbit recommendations:
+Harry Potter and the Philosopher's Stone and The Hobbit recommendations:
 [['Harry Potter and the Half-Blood Prince', 0.6018217616032179],
  ['Harry Potter and the Prisoner of Azkaban', 0.5989788027468591],
  ['The Magical Worlds of Harry Potter', 0.5909785871728664],
@@ -402,6 +452,16 @@ bert_tfidf_sim_matrix = tfidf_weight * tfidf_sim_matrix + bert_weight * bert_sim
  ['The Weirdstone of Brisingamen', 0.5725139741586933],
  ['The Children of Húrin', 0.5661655486061915],
  ['Harry Potter and the Goblet of Fire', 0.5653645423523244]]
+```
+
+The WikilinkNN model can be combined with other models by subsetting the similarity matrix for titles derived in the cleaning process:
+
+```python
+wikilink_sims_copy = wikilink_sims.copy()
+not_selected_idxs = [i for i in range(len(titles)) if i not in selected_idxs]
+
+wikilink_sims_copy = np.delete(wikilink_sims_copy, not_selected_idxs, axis=0)
+wikilink_sims_copy = np.delete(wikilink_sims_copy, not_selected_idxs, axis=1)
 ```
 
 <p>
@@ -490,18 +550,6 @@ model.recommend(
  ['Harry Potter and the Goblet of Fire', 0.5346379229854734],
  ['The Children of Húrin', 0.5340832788476909],
  ['A Wizard of Earthsea', 0.5297755576425843]]
-```
-
-<p>
-</details>
-
-<details><summary><strong>Wikilink NN</strong></summary>
-<p>
-
-```_output
--- Wikilink Neural Network Ratings --
-
-[]
 ```
 
 <p>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ copyright = "2020-2021, wikirec developers (BSD License)"
 author = "wikirec developers"
 
 # The full version, including alpha/beta/rc tags
-release = "0.2.1"
+release = "0.2.2"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -170,7 +170,7 @@ texinfo_documents = [
         "wikirec Documentation",
         author,
         "wikirec",
-        "NLP recommendation engine based on Wikipedia data",
+        "Recommendation engine framework based on Wikipedia data",
         "Miscellaneous",
     )
 ]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,7 +40,7 @@
 .. |colab| image:: https://img.shields.io/badge/%20-Open%20in%20Colab-097ABB.svg?logo=google-colab&color=097ABB&labelColor=525252
     :target: https://colab.research.google.com/github/andrewtavis/wikirec
 
-NLP recommendation engine based on Wikipedia data
+Recommendation engine framework based on Wikipedia data
 
 Installation
 ------------

--- a/examples/rec_books.ipynb
+++ b/examples/rec_books.ipynb
@@ -8,7 +8,7 @@
    },
    "source": [
     "<h1>Table of Contents<span class=\"tocSkip\"></span></h1>\n",
-    "<div class=\"toc\"><ul class=\"toc-item\"><li><span><a href=\"#Download-and-Clean-Data\" data-toc-modified-id=\"Download-and-Clean-Data-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>Download and Clean Data</a></span></li><li><span><a href=\"#Making-Recommendations\" data-toc-modified-id=\"Making-Recommendations-2\"><span class=\"toc-item-num\">2&nbsp;&nbsp;</span>Making Recommendations</a></span><ul class=\"toc-item\"><li><span><a href=\"#BERT\" data-toc-modified-id=\"BERT-2.1\"><span class=\"toc-item-num\">2.1&nbsp;&nbsp;</span>BERT</a></span></li><li><span><a href=\"#Doc2vec\" data-toc-modified-id=\"Doc2vec-2.2\"><span class=\"toc-item-num\">2.2&nbsp;&nbsp;</span>Doc2vec</a></span></li><li><span><a href=\"#LDA\" data-toc-modified-id=\"LDA-2.3\"><span class=\"toc-item-num\">2.3&nbsp;&nbsp;</span>LDA</a></span></li><li><span><a href=\"#TFIDF\" data-toc-modified-id=\"TFIDF-2.4\"><span class=\"toc-item-num\">2.4&nbsp;&nbsp;</span>TFIDF</a></span></li></ul></li></ul></div>"
+    "<div class=\"toc\"><ul class=\"toc-item\"><li><span><a href=\"#Download-and-Clean-Data\" data-toc-modified-id=\"Download-and-Clean-Data-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>Download and Clean Data</a></span></li><li><span><a href=\"#Making-Recommendations\" data-toc-modified-id=\"Making-Recommendations-2\"><span class=\"toc-item-num\">2&nbsp;&nbsp;</span>Making Recommendations</a></span><ul class=\"toc-item\"><li><span><a href=\"#BERT\" data-toc-modified-id=\"BERT-2.1\"><span class=\"toc-item-num\">2.1&nbsp;&nbsp;</span>BERT</a></span></li><li><span><a href=\"#Doc2vec\" data-toc-modified-id=\"Doc2vec-2.2\"><span class=\"toc-item-num\">2.2&nbsp;&nbsp;</span>Doc2vec</a></span></li><li><span><a href=\"#LDA\" data-toc-modified-id=\"LDA-2.3\"><span class=\"toc-item-num\">2.3&nbsp;&nbsp;</span>LDA</a></span></li><li><span><a href=\"#TFIDF\" data-toc-modified-id=\"TFIDF-2.4\"><span class=\"toc-item-num\">2.4&nbsp;&nbsp;</span>TFIDF</a></span></li><li><span><a href=\"#WikilinkNN\" data-toc-modified-id=\"WikilinkNN-2.5\"><span class=\"toc-item-num\">2.5&nbsp;&nbsp;</span>WikilinkNN</a></span></li><li><span><a href=\"#Weighted-Model\" data-toc-modified-id=\"Weighted-Model-2.6\"><span class=\"toc-item-num\">2.6&nbsp;&nbsp;</span>Weighted Model</a></span></li></ul></li></ul></div>"
    ]
   },
   {
@@ -1100,9 +1100,167 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "tropical-causing",
+   "metadata": {},
+   "source": [
+    "## WikilinkNN"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "joined-reasoning",
+   "id": "dedicated-marijuana",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We can pass kwargs for the WikilinkNN Keras model\n",
+    "wikilink_sim_matrix = load_or_create_sim_matrix(\n",
+    "    method=\"wikilinknn\",\n",
+    "    corpus=text_corpus,\n",
+    "    metric=\"cosine\",  # euclidean\n",
+    "    topic=topic,\n",
+    "    path=\"./\",\n",
+    "    embedding_size=75,\n",
+    "    epochs=20,\n",
+    "    verbose=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "computational-centre",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.recommend(\n",
+    "    inputs=single_input_0,\n",
+    "    titles=selected_titles,\n",
+    "    sim_matrix=wikilink_sim_matrix,\n",
+    "    n=10,\n",
+    "    metric=\"cosine\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "worse-spank",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.recommend(\n",
+    "    inputs=single_input_1,\n",
+    "    titles=selected_titles,\n",
+    "    sim_matrix=wikilink_sim_matrix,\n",
+    "    n=10,\n",
+    "    metric=\"cosine\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "english-marble",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.recommend(\n",
+    "    inputs=multiple_inputs,\n",
+    "    titles=selected_titles,\n",
+    "    sim_matrix=wikilink_sim_matrix,\n",
+    "    n=10,\n",
+    "    metric=\"cosine\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "premium-interface",
+   "metadata": {},
+   "source": [
+    "## Weighted Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "loving-volunteer",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# wikilink_sims_copy = wikilink_sims.copy()\n",
+    "# not_selected_idxs = [i for i in range(len(titles)) if i not in selected_idxs]\n",
+    "\n",
+    "# wikilink_sims_copy = np.delete(wikilink_sims_copy, not_selected_idxs, axis=0)\n",
+    "# wikilink_sims_copy = np.delete(wikilink_sims_copy, not_selected_idxs, axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "continuing-greene",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tfidf_weight = 0.35\n",
+    "bert_weight = 1.0 - tfidf_weight\n",
+    "bert_tfidf_sim_matrix = tfidf_weight * tfidf_sim_matrix + bert_weight * bert_sim_matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "particular-technique",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.recommend(\n",
+    "    inputs=single_input_0,\n",
+    "    titles=selected_titles,\n",
+    "    sim_matrix=bert_tfidf_sim_matrix,\n",
+    "    n=10,\n",
+    "    metric=\"cosine\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "hollow-money",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.recommend(\n",
+    "    inputs=single_input_1,\n",
+    "    titles=selected_titles,\n",
+    "    sim_matrix=bert_tfidf_sim_matrix,\n",
+    "    n=10,\n",
+    "    metric=\"cosine\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "random-campus",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.recommend(\n",
+    "    inputs=multiple_inputs,\n",
+    "    titles=selected_titles,\n",
+    "    sim_matrix=bert_tfidf_sim_matrix,\n",
+    "    n=10,\n",
+    "    metric=\"cosine\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "related-pavilion",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/examples/rec_movies.ipynb
+++ b/examples/rec_movies.ipynb
@@ -8,7 +8,7 @@
    },
    "source": [
     "<h1>Table of Contents<span class=\"tocSkip\"></span></h1>\n",
-    "<div class=\"toc\"><ul class=\"toc-item\"><li><span><a href=\"#Download-and-Clean-Data\" data-toc-modified-id=\"Download-and-Clean-Data-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>Download and Clean Data</a></span></li><li><span><a href=\"#Making-Recommendations\" data-toc-modified-id=\"Making-Recommendations-2\"><span class=\"toc-item-num\">2&nbsp;&nbsp;</span>Making Recommendations</a></span><ul class=\"toc-item\"><li><span><a href=\"#BERT\" data-toc-modified-id=\"BERT-2.1\"><span class=\"toc-item-num\">2.1&nbsp;&nbsp;</span>BERT</a></span></li><li><span><a href=\"#Doc2vec\" data-toc-modified-id=\"Doc2vec-2.2\"><span class=\"toc-item-num\">2.2&nbsp;&nbsp;</span>Doc2vec</a></span></li><li><span><a href=\"#LDA\" data-toc-modified-id=\"LDA-2.3\"><span class=\"toc-item-num\">2.3&nbsp;&nbsp;</span>LDA</a></span></li><li><span><a href=\"#TFIDF\" data-toc-modified-id=\"TFIDF-2.4\"><span class=\"toc-item-num\">2.4&nbsp;&nbsp;</span>TFIDF</a></span></li></ul></li></ul></div>"
+    "<div class=\"toc\"><ul class=\"toc-item\"><li><span><a href=\"#Download-and-Clean-Data\" data-toc-modified-id=\"Download-and-Clean-Data-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>Download and Clean Data</a></span></li><li><span><a href=\"#Making-Recommendations\" data-toc-modified-id=\"Making-Recommendations-2\"><span class=\"toc-item-num\">2&nbsp;&nbsp;</span>Making Recommendations</a></span><ul class=\"toc-item\"><li><span><a href=\"#BERT\" data-toc-modified-id=\"BERT-2.1\"><span class=\"toc-item-num\">2.1&nbsp;&nbsp;</span>BERT</a></span></li><li><span><a href=\"#Doc2vec\" data-toc-modified-id=\"Doc2vec-2.2\"><span class=\"toc-item-num\">2.2&nbsp;&nbsp;</span>Doc2vec</a></span></li><li><span><a href=\"#LDA\" data-toc-modified-id=\"LDA-2.3\"><span class=\"toc-item-num\">2.3&nbsp;&nbsp;</span>LDA</a></span></li><li><span><a href=\"#TFIDF\" data-toc-modified-id=\"TFIDF-2.4\"><span class=\"toc-item-num\">2.4&nbsp;&nbsp;</span>TFIDF</a></span></li><li><span><a href=\"#WikilinkNN\" data-toc-modified-id=\"WikilinkNN-2.5\"><span class=\"toc-item-num\">2.5&nbsp;&nbsp;</span>WikilinkNN</a></span></li><li><span><a href=\"#Weighted-Model\" data-toc-modified-id=\"Weighted-Model-2.6\"><span class=\"toc-item-num\">2.6&nbsp;&nbsp;</span>Weighted Model</a></span></li></ul></li></ul></div>"
    ]
   },
   {
@@ -714,9 +714,167 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "failing-stevens",
+   "metadata": {},
+   "source": [
+    "## WikilinkNN"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "spread-cleveland",
+   "id": "anticipated-divide",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We can pass kwargs for the WikilinkNN Keras model\n",
+    "wikilink_sim_matrix = load_or_create_sim_matrix(\n",
+    "    method=\"wikilinknn\",\n",
+    "    corpus=text_corpus,\n",
+    "    metric=\"cosine\",  # euclidean\n",
+    "    topic=topic,\n",
+    "    path=\"./\",\n",
+    "    embedding_size=75,\n",
+    "    epochs=20,\n",
+    "    verbose=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "mysterious-admission",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.recommend(\n",
+    "    inputs=single_input_0,\n",
+    "    titles=selected_titles,\n",
+    "    sim_matrix=wikilink_sim_matrix,\n",
+    "    n=10,\n",
+    "    metric=\"cosine\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "collectible-scenario",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.recommend(\n",
+    "    inputs=single_input_1,\n",
+    "    titles=selected_titles,\n",
+    "    sim_matrix=wikilink_sim_matrix,\n",
+    "    n=10,\n",
+    "    metric=\"cosine\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "senior-illustration",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.recommend(\n",
+    "    inputs=multiple_inputs,\n",
+    "    titles=selected_titles,\n",
+    "    sim_matrix=wikilink_sim_matrix,\n",
+    "    n=10,\n",
+    "    metric=\"cosine\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dental-relative",
+   "metadata": {},
+   "source": [
+    "## Weighted Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "psychological-checklist",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# wikilink_sims_copy = wikilink_sims.copy()\n",
+    "# not_selected_idxs = [i for i in range(len(titles)) if i not in selected_idxs]\n",
+    "\n",
+    "# wikilink_sims_copy = np.delete(wikilink_sims_copy, not_selected_idxs, axis=0)\n",
+    "# wikilink_sims_copy = np.delete(wikilink_sims_copy, not_selected_idxs, axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "million-packet",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tfidf_weight = 0.35\n",
+    "bert_weight = 1.0 - tfidf_weight\n",
+    "bert_tfidf_sim_matrix = tfidf_weight * tfidf_sim_matrix + bert_weight * bert_sim_matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "beginning-pharmaceutical",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.recommend(\n",
+    "    inputs=single_input_0,\n",
+    "    titles=selected_titles,\n",
+    "    sim_matrix=bert_tfidf_sim_matrix,\n",
+    "    n=10,\n",
+    "    metric=\"cosine\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "proved-boulder",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.recommend(\n",
+    "    inputs=single_input_1,\n",
+    "    titles=selected_titles,\n",
+    "    sim_matrix=bert_tfidf_sim_matrix,\n",
+    "    n=10,\n",
+    "    metric=\"cosine\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "positive-fusion",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.recommend(\n",
+    "    inputs=multiple_inputs,\n",
+    "    titles=selected_titles,\n",
+    "    sim_matrix=bert_tfidf_sim_matrix,\n",
+    "    n=10,\n",
+    "    metric=\"cosine\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "close-courage",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup_args = dict(
         "Programming Language :: Python :: 3.8",
         "Operating System :: OS Independent",
     ],
-    description="NLP recommendation engine based on Wikipedia data",
+    description="Recommendation engine framework based on Wikipedia data",
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="new BSD",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup_args = dict(
     name="wikirec",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
-    version="0.2.1",
+    version="0.2.2",
     author="Andrew Tavis McAllister",
     author_email="andrew.t.mcallister@gmail.com",
     classifiers=[

--- a/src/wikirec/data_utils.py
+++ b/src/wikirec/data_utils.py
@@ -100,23 +100,23 @@ def download_wiki(language="en", target_dir="wiki_dump", file_limit=-1, dump_id=
     Parameters
     ----------
         language : str (default=en)
-            The language of Wikipedia to download
+            The language of Wikipedia to download.
 
         target_dir : str (default=wiki_dump)
-            The directory in the pwd into which files should be downloaded
+            The directory in the pwd into which files should be downloaded.
 
         file_limit : int (default=-1, all files)
-            The limit for the number of files to download
+            The limit for the number of files to download.
 
         dump_id : str (default=False)
-            The id of an explicit Wikipedia dump that the user wants to download
+            The id of an explicit Wikipedia dump that the user wants to download.
 
-            Note: a value of False will select the third from the last (latest stable dump)
+            Note: a value of False will select the third from the last (latest stable dump).
 
     Returns
     -------
         file_info : list of lists
-            Information on the downloaded Wikipedia dump files
+            Information on the downloaded Wikipedia dump files.
     """
     assert isinstance(
         file_limit, int
@@ -208,18 +208,18 @@ def _process_article(title, text, templates="Infobox book"):
     Parameters
     ----------
         title : str
-            The title of the article
+            The title of the article.
 
         text : str
-            The text to be processed
+            The text to be processed.
 
         templates : str (default=Infobox book)
-            The target templates for the corpus
+            The target templates for the corpus.
 
     Returns
     -------
         title, text, wikilinks: string, string, list
-            The data from the article
+            The data from the article.
     """
     wikicode = mwparserfromhell.parse(text)
 
@@ -248,31 +248,31 @@ def iterate_and_parse_file(args):
     Parameters
     ----------
         args : tuple
-            The below arguments as a tuple to allow for pool.imap_unordered rather than pool.starmap
+            The below arguments as a tuple to allow for pool.imap_unordered rather than pool.starmap.
 
         topics : str
-            The topics that articles should be subset by
+            The topics that articles should be subset by.
 
-            Note: this corresponds to the type of infobox from Wikipedia articles
+            Note: this corresponds to the type of infobox from Wikipedia articles.
 
         language : str (default=en)
-            The language of Wikipedia that articles are being parsed for
+            The language of Wikipedia that articles are being parsed for.
 
         input_path : str
-            The path to the data file
+            The path to the data file.
 
         partitions_dir : str
-            The path to where output file should be stored
+            The path to where output file should be stored.
 
         limit : int optional (default=None)
-            An optional limit of the number of articles to find
+            An optional limit of the number of articles to find.
 
         verbose : bool
-            Whether to show a tqdm progress bar for the processes
+            Whether to show a tqdm progress bar for the processes.
 
     Returns
     -------
-        A parsed file Wikipedia dump file with articles of the specified topics
+        A parsed file Wikipedia dump file with articles of the specified topics.
     """
     topics, language, input_path, partitions_dir, limit, verbose = args
 
@@ -391,35 +391,35 @@ def parse_to_ndjson(
         topics : str (default=books)
             The topics that articles should be subset by.
 
-            Note: this corresponds to the type of infobox from Wikipedia articles
+            Note: this corresponds to the type of infobox from Wikipedia articles.
 
         language : str (default=en)
-            The language of Wikipedia that articles are being parsed for
+            The language of Wikipedia that articles are being parsed for.
 
         output_path : str (default=topic_articles)
-            The name of the final output ndjson file
+            The name of the final output ndjson file.
 
         input_dir : str (default=wikipedia_dump)
-            The path to the directory where the data is stored
+            The path to the directory where the data is stored.
 
         partitions_dir : str (default=partitions)
-            The path to the directory where the output should be stored
+            The path to the directory where the output should be stored.
 
         limit : int (default=None)
-            An optional limit of the number of topic articles per dump file to find
+            An optional limit of the number of topic articles per dump file to find.
 
         delete_parsed_files : bool (default=False)
-            Whether to delete the separate parsed files after combining them
+            Whether to delete the separate parsed files after combining them.
 
         multicore : bool (default=True)
-            Whether to use multicore processesing
+            Whether to use multicore processesing.
 
         verbose : bool (default=True)
-            Whether to show a tqdm progress bar for the processes
+            Whether to show a tqdm progress bar for the processes.
 
     Returns
     -------
-        Wikipedia dump files parsed for the given template types and converted to json files
+        Wikipedia dump files parsed for the given template types and converted to json files.
     """
     output_dir = "/".join([i for i in output_path.split("/")[:-1]])
     if not os.path.exists(output_dir):
@@ -482,7 +482,9 @@ def parse_to_ndjson(
                     pass
 
         def read_and_combine_json(file_path):
-            """Read in json data from a file_path."""
+            """
+            Read in json data from a file_path.
+            """
             data = []
 
             with open(file_path, "r") as f:
@@ -528,12 +530,12 @@ def _combine_tokens_to_str(tokens):
     Parameters
     ----------
         tokens : str or list
-            The texts to be combined
+            The texts to be combined.
 
     Returns
     -------
         texts_str : str
-            A string of the full text with unwanted words removed
+            A string of the full text with unwanted words removed.
     """
     if isinstance(tokens[0], list):
         flat_words = [word for sublist in tokens for word in sublist]
@@ -550,29 +552,29 @@ def _lower_remove_unwanted(args):
     Parameters
     ----------
         args : list of tuples
-            The following arguments zipped
+            The following arguments zipped.
 
         text : list
-            The text to clean
+            The text to clean.
 
         remove_names : bool
-            Whether to remove names
+            Whether to remove names.
 
         words_to_ignore : str or list
-                Strings that should be removed from the text body
+                Strings that should be removed from the text body.
 
         stop_words : str or list
-            Stopwords for the given language
+            Stopwords for the given language.
 
     Returns
     -------
         text_lower : list
-            The text with lowercased tokens and without unwanted tokens
+            The text with lowercased tokens and without unwanted tokens.
     """
     text, remove_names, words_to_ignore, stop_words = args
 
     if remove_names:
-        # Remove names, numbers, words_to_ignore and stop_words after n-grams have been created
+        # Remove names, numbers, words_to_ignore and stop_words after n-grams have been created.
         return [
             token.lower()
             for token in text
@@ -583,7 +585,7 @@ def _lower_remove_unwanted(args):
             and token not in stop_words
         ]
     else:
-        # Or simply lower case tokens and remove non-bigrammed numbers, words_to_ignore and stop_words
+        # Or simply lower case tokens and remove non-bigrammed numbers, words_to_ignore and stop_words.
         return [
             token.lower()
             for token in text
@@ -601,18 +603,18 @@ def _lemmatize(tokens, nlp=None, verbose=True):
     Parameters
     ----------
         tokens : list or list of lists
-            Tokens to be lemmatized
+            Tokens to be lemmatized.
 
         nlp : spacy.load object
-            A spacy language model
+            A spacy language model.
 
         verbose : bool (default=True)
-            Whether to show a tqdm progress bar for the query
+            Whether to show a tqdm progress bar for the query.
 
     Returns
     -------
         lemmatized_tokens : list or list of lists
-            Tokens that have been lemmatized for nlp analysis
+            Tokens that have been lemmatized for nlp analysis.
     """
     allowed_pos_tags = ["NOUN", "PROPN", "ADJ", "ADV", "VERB"]
 
@@ -643,18 +645,18 @@ def _subset_and_combine_tokens(args):
         Parameters
         ----------
             args : list of tuples
-                The following arguments zipped
+                The following arguments zipped.
 
             text : list
-                The list of tokens to be subsetted for and combined
+                The list of tokens to be subsetted for and combined.
 
             max_token_index : int (default=-1)
-                The maximum allowable length of a tokenized text
+                The maximum allowable length of a tokenized text.
 
         Returns
         -------
             sub_comb_text : tuple
-                An index and its combined text
+                An index and its combined text.
         """
     text, max_token_index = args
 
@@ -684,49 +686,49 @@ def clean(
     Parameters
     ----------
         texts : str or list
-            The texts to be cleaned and tokenized
+            The texts to be cleaned and tokenized.
 
         language : str (default=en)
-            The language of Wikipedia to download
+            The language of Wikipedia to download.
 
         min_token_freq : int (default=2)
-            The minimum allowable frequency of a word inside the corpus
+            The minimum allowable frequency of a word inside the corpus.
 
         min_token_len : int (default=3)
-            The smallest allowable length of a word
+            The smallest allowable length of a word.
 
         min_tokens : int (default=0)
-            The minimum allowable length of a tokenized text
+            The minimum allowable length of a tokenized text.
 
         max_token_index : int (default=-1)
-            The maximum allowable length of a tokenized text
+            The maximum allowable length of a tokenized text.
 
         min_ngram_count : int (default=5)
-            The minimum occurrences for an n-gram to be included
+            The minimum occurrences for an n-gram to be included.
 
         remove_stopwords : bool (default=True)
-            Whether to remove stopwords
+            Whether to remove stopwords.
 
         ignore_words : str or list
-            Strings that should be removed from the text body
+            Strings that should be removed from the text body.
 
         remove_names : bool (default=False)
-            Whether to remove common names
+            Whether to remove common names.
 
         sample_size : float (default=1)
-            The amount of data to be randomly sampled
+            The amount of data to be randomly sampled.
 
         verbose : bool (default=True)
-            Whether to show a tqdm progress bar for the query
+            Whether to show a tqdm progress bar for the query.
 
     Returns
     -------
         text_corpus, selected_idxs : list, list
-            The texts formatted for text analysis as well as the indexes for selected entries
+            The texts formatted for text analysis as well as the indexes for selected entries.
     """
     language = language.lower()
 
-    # Select abbreviation for the lemmatizer, if it's available
+    # Select abbreviation for the lemmatizer, if it's available.
     if language in languages.lem_abbr_dict().keys():
         language = languages.lem_abbr_dict()[language]
 
@@ -743,7 +745,7 @@ def clean(
         if stopwords(language) != set():  # the input language has stopwords
             stop_words = stopwords(language)
 
-        # Stemming and normal stopwords are still full language names
+        # Stemming and normal stopwords are still full language names.
         elif language in languages.stem_abbr_dict().keys():
             stop_words = stopwords(languages.stem_abbr_dict()[language])
 
@@ -753,7 +755,7 @@ def clean(
     pbar = tqdm(
         desc="Cleaning steps complete", total=7, unit="step", disable=not verbose
     )
-    # Remove spaces that are greater that one in length
+    # Remove spaces that are greater that one in length.
     texts_no_large_spaces = []
     for t in texts:
         for i in range(
@@ -774,9 +776,9 @@ def clean(
 
         texts_no_websites.append(t)
 
-    # Remove the references section but maintain the categories if they exist
-    # The reference are in the text, so this just removes the section and external links
-    # References are maintained for references like awards
+    # Remove the references section but maintain the categories if they exist.
+    # The reference are in the text, so this just removes the section and external links.
+    # References are maintained for references like awards.
     texts_no_references = []
     for t in texts_no_websites:
         if "Category:" in t:
@@ -790,7 +792,7 @@ def clean(
     pbar.update()
 
     texts_no_random_punctuation = []
-    # Prevent words from being combined when a user types word/word or word-word or word:word
+    # Prevent words from being combined when a user types word/word or word-word or word:word.
     for t in texts_no_references:
         t = t.replace("/", " ")
         t = t.replace("-", " ")
@@ -805,14 +807,14 @@ def clean(
         for r in texts_no_random_punctuation
     ]
 
-    # We lower case after names are removed to allow for filtering out capitalized words
+    # We lower case after names are removed to allow for filtering out capitalized words.
     tokenized_texts = [text.split() for text in texts_no_punctuation]
 
     gc.collect()
     pbar.update()
 
-    # Add bigrams and trigrams
-    # Half the normal threshold
+    # Add bigrams and trigrams.
+    # Use half the normal threshold.
     if gensim.__version__[0] == "4":
         bigrams = Phrases(
             sentences=tokenized_texts,
@@ -850,12 +852,12 @@ def clean(
     ):
         for token in bigrams[text]:
             if token.count("_") == 1:
-                # Token is a bigram, so add it to the tokens
+                # Token is a bigram, so add it to the tokens.
                 text.insert(0, token)
 
         for token in trigrams[bigrams[text]]:
             if token.count("_") == 2:
-                # Token is a trigram, so add it to the tokens
+                # Token is a trigram, so add it to the tokens.
                 text.insert(0, token)
 
         tokens_with_ngrams.append(text)
@@ -886,7 +888,7 @@ def clean(
     gc.collect()
     pbar.update()
 
-    # Try lemmatization, and if not available stem, and if not available nothing
+    # Try lemmatization, and if not available stem, and if not available nothing.
     try:
         nlp = spacy.load(language)
         base_tokens = _lemmatize(tokens=tokens_lower, nlp=nlp, verbose=verbose)
@@ -901,12 +903,12 @@ def clean(
             nlp = None
 
     if nlp is None:
-        # Lemmatization failed, so try stemming
+        # Lemmatization failed, so try stemming.
         stemmer = None
         if language in SnowballStemmer.languages:
             stemmer = SnowballStemmer(language)
 
-        # Correct if the abbreviations were put in
+        # Correct if the abbreviations were put in.
         elif language == "ar":
             stemmer = SnowballStemmer("arabic")
 
@@ -920,11 +922,11 @@ def clean(
             stemmer = SnowballStemmer("swedish")
 
         if stemmer is None:
-            # We cannot lemmatize or stem
+            # We cannot lemmatize or stem.
             base_tokens = tokens_lower
 
         else:
-            # Stemming instead of lemmatization
+            # Stemming instead of lemmatization.
             base_tokens = []
             for tokens in tqdm(
                 tokens_lower,
@@ -951,10 +953,10 @@ def clean(
 
     assert isinstance(
         min_token_len, int
-    ), "The 'min_token_len' argument must be an integer if used"
+    ), "The 'min_token_len' argument must be an integer if used."
     assert isinstance(
         min_token_freq, int
-    ), "The 'min_token_freq' argument must be an integer if used"
+    ), "The 'min_token_freq' argument must be an integer if used."
 
     min_len_freq_tokens = [
         [
@@ -968,7 +970,7 @@ def clean(
     gc.collect()
     pbar.update()
 
-    # Save original length for sampling
+    # Save original length for sampling.
     original_len = len(min_len_freq_tokens)
     min_sized_texts = [
         [i, t] for i, t in enumerate(min_len_freq_tokens) if len(t) > min_tokens
@@ -989,7 +991,7 @@ def clean(
 
     gc.collect()
 
-    # Sample texts
+    # Sample texts.
     if len(text_corpus) > int(sample_size * original_len):
         idxs = [t[0] for t in text_corpus]
         selected_idxs = np.random.choice(
@@ -1006,7 +1008,9 @@ def clean(
 
 
 class WikiXmlHandler(xml.sax.handler.ContentHandler):
-    """Parse through XML data using SAX."""
+    """
+    Parse through XML data using SAX.
+    """
 
     def __init__(self):
         xml.sax.handler.ContentHandler.__init__(self)
@@ -1017,18 +1021,24 @@ class WikiXmlHandler(xml.sax.handler.ContentHandler):
         self._target_articles = []
 
     def characters(self, content):
-        """Characters between opening and closing tags."""
+        """
+        Characters between opening and closing tags.
+        """
         if self._current_tag:
             self._buffer.append(content)
 
     def startElement(self, name, attrs):
-        """Opening tag of element."""
+        """
+        Opening tag of element.
+        """
         if name in ("title", "text"):
             self._current_tag = name
             self._buffer = []
 
     def endElement(self, name):
-        """Closing tag of element."""
+        """
+        Closing tag of element.
+        """
         if name == self._current_tag:
             self._values[name] = " ".join(self._buffer)
 

--- a/src/wikirec/languages.py
+++ b/src/wikirec/languages.py
@@ -4,7 +4,7 @@ languages
 
 Module for organizing language dependencies for text cleaning.
 
-The following languages have been selected because their stopwords can be removed via https://github.com/stopwords-iso/stopwords-iso/tree/master/python
+The following languages have been selected because their stopwords can be removed via https://github.com/stopwords-iso/stopwords-iso/tree/master/python.
 
 Contents:
     lem_abbr_dict,
@@ -19,14 +19,14 @@ def lem_abbr_dict():
 
     Notes
     -----
-        These languages can be lemmatized via https://spacy.io/usage/models
+        These languages can be lemmatized via https://spacy.io/usage/models.
 
-        They are also those that can have their words ordered by parts of speech
+        They are also those that can have their words ordered by parts of speech.
 
     Returns
     -------
         lem_abbr_dict : dict
-            A dictionary with languages as keys and their abbreviations as items
+            A dictionary with languages as keys and their abbreviations as items.
     """
     return {
         "chinese": "zh",
@@ -53,12 +53,12 @@ def stem_abbr_dict():
 
     Notes
     -----
-        These languages don't have good lemmatizers, and will thus be stemmed via https://www.nltk.org/api/nltk.stem.html
+        These languages don't have good lemmatizers, and will thus be stemmed via https://www.nltk.org/api/nltk.stem.html.
 
     Returns
     -------
         stem_abbr_dict : dict
-            A dictionary with languages as keys and their abbreviations as items
+            A dictionary with languages as keys and their abbreviations as items.
     """
     return {
         "arabic": "ar",
@@ -74,12 +74,12 @@ def sw_abbr_dict():
 
     Notes
     -----
-        These languages can only have their stopwords removed via https://github.com/stopwords-iso/stopwords-iso)
+        These languages can only have their stopwords removed via https://github.com/stopwords-iso/stopwords-iso).
 
     Returns
     -------
         sw_abbr_dict : dict
-            A dictionary with languages as keys and their abbreviations as items
+            A dictionary with languages as keys and their abbreviations as items.
     """
     return {
         "afrikaans": "af",

--- a/src/wikirec/model.py
+++ b/src/wikirec/model.py
@@ -94,7 +94,7 @@ def gen_embeddings(
     """
     method = method.lower()
 
-    valid_methods = ["bert", "doc2vec", "lda", "tfidf"]
+    valid_methods = ["bert", "doc2vec", "lda", "tfidf", "wikilinks"]
 
     if method not in valid_methods:
         raise ValueError(

--- a/src/wikirec/model.py
+++ b/src/wikirec/model.py
@@ -163,7 +163,7 @@ def gen_embeddings(
             embeddings = weights / np.linalg.norm(weights, axis = 1).reshape((-1, 1))
             return embeddings
         else:
-            embeddings = _wikilinks_nn()
+            embeddings = _wikilinks_nn('./enwiki_books.ndjson', 50)
             return embeddings
 
 

--- a/src/wikirec/utils.py
+++ b/src/wikirec/utils.py
@@ -51,7 +51,7 @@ def _check_str_args(arguments, valid_args):
         return
 
     elif isinstance(arguments, list):
-        # Check arguments, and remove them if they're invalid
+        # Check arguments, and remove them if they're invalid.
         for a in arguments:
             _check_str_args(arguments=a, valid_args=valid_args)
 
@@ -72,34 +72,34 @@ def graph_lda_topic_evals(
     Parameters
     ----------
         corpus : list of lists (default=None)
-            The text corpus over which analysis should be done
+            The text corpus over which analysis should be done.
 
         num_topic_words : int (default=10)
-            The number of keywords that should be extracted
+            The number of keywords that should be extracted.
 
         topic_nums_to_compare : list (default=None)
-            The number of topics to compare metrics over
+            The number of topics to compare metrics over.
 
-            Note: None selects all numbers from 1 to num_topic_words
+            Note: None selects all numbers from 1 to num_topic_words.
 
         metrics : str or bool (default=True: all metrics)
-            The metrics to include
+            The metrics to include.
 
             Options:
-                stability: model stability based on Jaccard similarity
+                stability: model stability based on Jaccard similarity.
 
-                coherence: how much the words associated with model topics co-occur
+                coherence: how much the words associated with model topics co-occur.
 
         verbose : bool (default=True)
-            Whether to show a tqdm progress bar for the query
+            Whether to show a tqdm progress bar for the query.
 
         **kwargs : keyword arguments
-            Arguments correspoding to gensim.models.ldamulticore.LdaMulticore
+            Arguments correspoding to gensim.models.ldamulticore.LdaMulticore.
 
     Returns
     -------
         ax : matplotlib axis
-            A graph of the given metrics for each of the given models based on each topic number
+            A graph of the given metrics for each of the given models based on each topic number.
     """
     assert (
         metrics == "stability" or metrics == "coherence" or metrics == True
@@ -118,11 +118,11 @@ def graph_lda_topic_evals(
         Notes
         -----
             Jaccard similarity:
-                - A statistic used for comparing the similarity and diversity of sample sets
-                - J(A,B) = (A ∩ B)/(A ∪ B)
-                - Goal is low Jaccard scores for coverage of the diverse elements
+                - A statistic used for comparing the similarity and diversity of sample sets.
+                - J(A,B) = (A ∩ B)/(A ∪ B).
+                - Goal is low Jaccard scores for coverage of the diverse elements.
         """
-        # Fix for cases where there are not enough texts for clustering models
+        # Fix for cases where there are not enough texts for clustering models.
         if topic_1 == [] and topic_2 != []:
             topic_1 = topic_2
         if topic_1 != [] and topic_2 == []:
@@ -137,12 +137,12 @@ def graph_lda_topic_evals(
 
         return num_intersect / num_union
 
-    plt.figure()  # begin figure
+    plt.figure()
 
     dirichlet_dict = corpora.Dictionary(corpus)
     bow_corpus = [dirichlet_dict.doc2bow(text) for text in corpus]
 
-    # Add an extra topic so that metrics can be calculated all inputs
+    # Add an extra topic so that metrics can be calculated all inputs.
     if topic_nums_to_compare == None:
         topic_nums_to_compare = list(range(num_topic_words + 1)[1:])
     else:
@@ -193,15 +193,16 @@ def graph_lda_topic_evals(
         for i in topic_nums_to_compare[:-1]
     ]
 
+    # Limit topic numbers to the number of keywords.
     coh_sta_diffs = [
         coherences[i] - mean_stabilities[i]
         for i in range(len(topic_nums_to_compare))[:-1]
-    ]  # limit topic numbers to the number of keywords
+    ]
     coh_sta_max = max(coh_sta_diffs)
     coh_sta_max_idxs = [i for i, j in enumerate(coh_sta_diffs) if j == coh_sta_max]
-    ideal_topic_num_index = coh_sta_max_idxs[
-        0
-    ]  # choose less topics in case there's more than one max
+
+    # Choose less topics in case there's more than one max.
+    ideal_topic_num_index = coh_sta_max_idxs[0]
     ideal_topic_num = topic_nums_to_compare[ideal_topic_num_index]
 
     ax = sns.lineplot(
@@ -216,7 +217,7 @@ def graph_lda_topic_evals(
         xmin=ideal_topic_num - 1, xmax=ideal_topic_num + 1, alpha=0.5, facecolor="grey"
     )
 
-    # Set plot limits
+    # Set plot limits.
     y_max = max(max(mean_stabilities), max(coherences)) + (
         0.10 * max(max(mean_stabilities), max(coherences))
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ files = data_utils.download_wiki(
     language=language, target_dir=input_dir, file_limit=1, dump_id=False
 )
 
-# To check that it finds already downloaded file
+# To check that it finds already downloaded file.
 files = data_utils.download_wiki(
     language=language, target_dir=input_dir, file_limit=1, dump_id=False
 )
@@ -47,7 +47,7 @@ dump_file_path = f"{input_dir}/{os.listdir(input_dir)[0]}"
 parse_args = ("books", language, dump_file_path, partitions_dir, limit, True)
 data_utils.iterate_and_parse_file(args=parse_args)
 
-# Again to check that it skips the parse
+# Again to check that it skips the parse.
 data_utils.iterate_and_parse_file(args=parse_args)
 
 with open(output_path, "r") as f:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -10,26 +10,6 @@ from wikirec import model
 np.random.seed(42)
 
 
-# def test_wikilinksnn(titles):
-#     n = 5
-
-#     wikilink_embeddings = model.gen_embeddings(
-#         method="WikilinkNN",
-#         path_to_json="./test_files/enwiki_books.ndjson",  # json used instead of a corpus
-#         embedding_size=50,
-#     )
-
-#     recs = model.recommend(
-#         inputs=titles[0],
-#         titles=titles,
-#         sim_matrix=wikilink_embeddings,
-#         n=n,
-#         metric="euclidean",
-#     )
-
-#     assert len(recs) == n
-
-
 def test_gen_sim_matrix(text_corpus):
     bert_embeddings = model.gen_embeddings(
         method="bert",

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -10,6 +10,26 @@ from wikirec import model
 np.random.seed(42)
 
 
+# def test_wikilinksnn(titles):
+#     n = 5
+
+#     wikilink_embeddings = model.gen_embeddings(
+#         method="WikilinkNN",
+#         path_to_json="./test_files/enwiki_books.ndjson",  # json used instead of a corpus
+#         embedding_size=50,
+#     )
+
+#     recs = model.recommend(
+#         inputs=titles[0],
+#         titles=titles,
+#         sim_matrix=wikilink_embeddings,
+#         n=n,
+#         metric="euclidean",
+#     )
+
+#     assert len(recs) == n
+
+
 def test_gen_sim_matrix(text_corpus):
     bert_embeddings = model.gen_embeddings(
         method="bert",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,7 @@ def test__check_str_args():
         "word_0",
         "word_1",
     ]
-    assert utils._check_str_args("word_2", ["word_0", "word_1"]) == None
+    assert utils._check_str_args("word_2", ["word_0", "word_1"]) is None
 
 
 def test_graph_lda_topic_evals(monkeypatch, text_corpus):


### PR DESCRIPTION
I'm a bit concerned this might be adding too much at once (and there will be stylistic/usability changes here and there), but I think most of the framework is here. I totally anticipate that changes will need to be made to clean things up. For example, the method only works with the `books` topics, and cleans data based on that assumption. Below is a list of what I tried to add:

- New method argument under `model.gen_embeddings()`, called `wikilinks`
- If `wikilinks` it will try to load a pre-trained model (I uploaded this under */examples/wikilinks_embedding_model.h5*). Ideally, this would be part of the repo, and would be sufficient for playing around with the method (although it's on the larger size > 50 MB). 
- If there is no pre-trained model available, it will call `_wikilinks_nn(...)`, which loads the `enwiki_books.ndjson` and builds/trains a neural network model on the wikilinks (this was adapted from the blogpost).
- Full disclosure: I haven't tested the method without already having */examples/wikilinks_embedding_model.h5*. So, I would want to run `_wikilinks_nn(..)` all the way through. But, the code was taken from my working Google Colab so I assumed it'd be ok. Let me know if I should run this all the way through before we can merge the PR. 

For verification, I did a lot of the testing in a personal Google Colab notebook; here were the recommendations for War and Peace! 
![image](https://user-images.githubusercontent.com/26015263/116602620-f6733300-a8f9-11eb-9d9a-ebe8327a0a31.png)
